### PR TITLE
Add a utility header encompassing functions for vectors and their associated operations

### DIFF
--- a/include/ops/vec_ops_core.hpp
+++ b/include/ops/vec_ops_core.hpp
@@ -263,7 +263,7 @@ inline auto scal_core<double>(double alpha, double* v1, size_t size) -> double* 
 
 template<typename T>
 inline auto __norm2_core_simd(const T* v1, size_t size) -> T {
-    auto r = 0;
+    T r = 0;
     #pragma omp simd reduction(+:r)
     for (auto i = 0u; i < size; ++i) {
         r += v1[i] * v1[i];
@@ -279,7 +279,7 @@ inline auto norm2_core(const T* v1, size_t size) -> T {
 
 template<>
 inline auto norm2_core<float>(const float* v1, size_t size) -> float {
-    auto norm = 0;
+    float norm = 0;
     #if defined(LALIB_BLAS_BACKEND)    
     norm = cblas_snrm2(size, v1, 1);
     #else 
@@ -290,7 +290,7 @@ inline auto norm2_core<float>(const float* v1, size_t size) -> float {
 
 template<>
 inline auto norm2_core<double>(const double* v1, size_t size) -> double {
-    auto norm = 0;
+    double norm = 0;
     #if defined(LALIB_BLAS_BACKEND)    
     norm = cblas_dnrm2(size, v1, 1);
     #else 

--- a/include/vec.hpp
+++ b/include/vec.hpp
@@ -1,0 +1,19 @@
+#pragma once 
+
+#include "vec/sized_vec.hpp"
+#include "vec/dyn_vec.hpp"
+#include "ops/vec_ops.hpp"
+
+namespace lalib {
+
+template<size_t N> using VecF = SizedVec<float, N>;
+template<size_t N> using VecD = SizedVec<double, N>;
+template<size_t N> using VecC = SizedVec<std::complex<float>, N>;
+template<size_t N> using VecZ = SizedVec<std::complex<double>, N>;
+
+using DynVecF = DynVec<float>;
+using DynVecD = DynVec<double>;
+using DynVecC = DynVec<std::complex<float>>;
+using DynVecZ = DynVec<std::complex<double>>;
+
+}

--- a/include/vec/dyn_vec.hpp
+++ b/include/vec/dyn_vec.hpp
@@ -77,6 +77,8 @@ public:
     template<size_t N> constexpr auto dot(const SizedVec<T, N>& v) const -> T;
     constexpr auto dot(const DynVec<T>& v) const -> T;
 
+    constexpr auto norm2() const noexcept -> T;
+
 private:
     std::vector<T> _elems;
 
@@ -167,6 +169,14 @@ inline constexpr auto DynVec<T>::dot(const DynVec<T> &v) const -> T
     this->__check_size(this->size(), v.size());
     d = dot_core(this->data(), v.data(), this->size());
     return d;
+}
+
+template <typename T>
+inline constexpr auto DynVec<T>::norm2() const noexcept -> T
+{
+    T norm;
+    norm = norm2_core(this->data(), this->size());
+    return norm;
 }
 
 // === Specializations of utility templates === //

--- a/include/vec/sized_vec.hpp
+++ b/include/vec/sized_vec.hpp
@@ -62,6 +62,8 @@ public:
     constexpr auto dot(const SizedVec<T, N>& v) const noexcept -> T;
     constexpr auto dot(const DynVec<T>& v) const noexcept -> T;
 
+    constexpr auto norm2() const noexcept -> T;
+
 private:
     std::array<T, N> _elems;
 
@@ -168,6 +170,14 @@ inline constexpr auto SizedVec<T, N>::dot(const DynVec<T> &v) const noexcept -> 
     T d;
     d = dot_core(this->data(), v.data(), this->size());
     return d;
+}
+
+template <typename T, size_t N>
+inline constexpr auto SizedVec<T, N>::norm2() const noexcept -> T
+{
+    T norm;
+    norm = norm2_core(this->data(), this->size());
+    return norm;
 }
 
 // === Specializations of utility templates === //

--- a/test/vec/dyn_vec.cc
+++ b/test/vec/dyn_vec.cc
@@ -84,3 +84,9 @@ TEST(DynVecTests, DotTestSizeMismatched) {
         vec_error::SizeMismatched
     );
 }
+
+TEST(DynVecTests, Norm2Test) {
+    auto v = lalib::DynVec<double> ({ 1.0, 2.0, 3.0, 4.0 });
+
+    ASSERT_DOUBLE_EQ(std::sqrt(30.0), v.norm2());
+}

--- a/test/vec/sized_vec.cc
+++ b/test/vec/sized_vec.cc
@@ -49,3 +49,9 @@ TEST(SizedVecTets, DotTest) {
 
     ASSERT_DOUBLE_EQ(10.0, v1.dot(v2));
 }
+
+TEST(SizedVecTets, Norm2Test) {
+    auto v = lalib::SizedVec<double, 4> ({ 1.0, 2.0, 3.0, 4.0 });
+
+    ASSERT_DOUBLE_EQ(std::sqrt(30), v.norm2());
+}


### PR DESCRIPTION
# Overview
This pull request introduces a utility header file `vec.hpp` that includes some header files that are related to the vectors and their associated operations. Users can access the features about vectors only including this header.

The L2 norm features for the vector classes are also added in this pull request.
While implementing those features, certain bugs are found in the logic calculating the L2 norm in `vector_ops_core.hpp`, which is fixed.

# Related Issues
None