### PR TITLE
Fix a bug related to scalar-vector multiplication

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(lalib VERSION 0.0.1 LANGUAGES C CXX)
+project(lalib VERSION 0.0.2 LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED True)

--- a/include/ops/vec_ops.hpp
+++ b/include/ops/vec_ops.hpp
@@ -286,16 +286,14 @@ auto scaled(T alpha, const DynVec<T>& x) noexcept -> DynVec<T> {
 
 template<typename T, size_t N>
 auto operator*(T alpha, const SizedVec<T, N>& x) noexcept -> SizedVec<T, N> {
-    auto r = SizedVec<T, N>::uninit();
-    std::memcpy(r.data(), x.data(), x.size());
+    auto r = x;
     scal_core(alpha, r.data(), r.size());
     return r;
 }
 
 template<typename T>
 auto operator*(T alpha, const DynVec<T>& x) noexcept -> DynVec<T> {
-    auto r = DynVec<T>::uninit();
-    std::memcpy(r.data(), x.data(), x.size());
+    auto r = x;
     scal_core(alpha, r.data(), r.size());
     return r;
 }

--- a/test/ops/vec_ops.cc
+++ b/test/ops/vec_ops.cc
@@ -129,6 +129,17 @@ TEST(VecOpsTests, SizedVecScalarScaleTest) {
     ASSERT_DOUBLE_EQ(6.0, v1[2]);
 }
 
+TEST(VecOpsTests, SizedVecScalarScaleOpTest) {
+    double alpha = 2.0;
+    auto v1 = lalib::SizedVec<double, 3>({1.0, 2.0, 3.0});
+
+    auto vr = alpha * v1;
+
+    ASSERT_DOUBLE_EQ(2.0, vr[0]);
+    ASSERT_DOUBLE_EQ(4.0, vr[1]);
+    ASSERT_DOUBLE_EQ(6.0, vr[2]);
+}
+
 TEST(VecOpsTests, DynVecAxpyTest) {
     double alpha = 2.0;
     auto v1 = lalib::DynVec<double>({1.0, 2.0, 3.0, 2.0, 4.0});
@@ -157,4 +168,17 @@ TEST(VecOpsTests, DynVecScalarScaleTest) {
     ASSERT_DOUBLE_EQ(9.0, v1[2]);
     ASSERT_DOUBLE_EQ(6.0, v1[3]);
     ASSERT_DOUBLE_EQ(12.0, v1[4]);
+}
+
+TEST(VecOpsTests, DynVecScalarScaleOpTest) {
+    double alpha = 3.0;
+    auto v1 = lalib::DynVec<double>({1.0, 2.0, 3.0, 2.0, 4.0});
+
+    auto vr = alpha * v1;
+
+    ASSERT_DOUBLE_EQ(3.0, vr[0]);
+    ASSERT_DOUBLE_EQ(6.0, vr[1]);
+    ASSERT_DOUBLE_EQ(9.0, vr[2]);
+    ASSERT_DOUBLE_EQ(6.0, vr[3]);
+    ASSERT_DOUBLE_EQ(12.0, vr[4]);
 }


### PR DESCRIPTION
# Overview
This pull request resolves a bug related to scalar-vector multiplication, specifically one leads to a zero calculation result when using `*` operator. The issue was caused by an invalid memory copy during the operation, and the pertinent code has been rectified in this update.
The patch number in the root `CMakeLists.txt` has also been updated.