### PR TITLE
Add some scalar-vector operations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(lalib VERSION 0.0.2 LANGUAGES C CXX)
+project(lalib VERSION 0.1.2 LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED True)

--- a/include/ops/ops_traits.hpp
+++ b/include/ops/ops_traits.hpp
@@ -1,0 +1,19 @@
+#pragma once
+#include <concepts>
+#include <complex>
+
+namespace lalib {
+
+template<typename T>
+requires std::floating_point<T>
+constexpr auto reciprocal(const T& val) noexcept {
+    return 1.0 / val;
+}
+
+template<typename T>
+requires std::floating_point<T>
+constexpr auto reciprocal(const std::complex<T>& val) noexcept {
+    return 1.0 / val;
+}
+
+}

--- a/include/ops/vec_ops.hpp
+++ b/include/ops/vec_ops.hpp
@@ -3,6 +3,7 @@
 #include "../vec/dyn_vec.hpp"
 #include "../err/error.hpp"
 #include "vec_ops_core.hpp"
+#include "ops_traits.hpp"
 
 #include <cstring>
 
@@ -295,6 +296,34 @@ template<typename T>
 auto operator*(T alpha, const DynVec<T>& x) noexcept -> DynVec<T> {
     auto r = x;
     scal_core(alpha, r.data(), r.size());
+    return r;
+}
+
+template<typename T, size_t N>
+auto operator*(const SizedVec<T, N>& x, T alpha) noexcept -> SizedVec<T, N> {
+    auto r = x;
+    scal_core(alpha, r.data(), r.size());
+    return r;
+}
+
+template<typename T>
+auto operator*(const DynVec<T>& x, T alpha) noexcept -> DynVec<T> {
+    auto r = x;
+    scal_core(alpha, r.data(), r.size());
+    return r;
+}
+
+template<typename T, size_t N>
+auto operator/(const SizedVec<T, N>& x, T alpha) noexcept -> SizedVec<T, N> {
+    auto r = x;
+    scal_core(reciprocal(alpha), r.data(), r.size());
+    return r;
+}
+
+template<typename T>
+auto operator/(const DynVec<T>& x, T alpha) noexcept -> DynVec<T> {
+    auto r = x;
+    scal_core(reciprocal(alpha), r.data(), r.size());
     return r;
 }
 

--- a/test/ops/vec_ops.cc
+++ b/test/ops/vec_ops.cc
@@ -134,10 +134,26 @@ TEST(VecOpsTests, SizedVecScalarScaleOpTest) {
     auto v1 = lalib::SizedVec<double, 3>({1.0, 2.0, 3.0});
 
     auto vr = alpha * v1;
+    auto vr1 = v1 * alpha;
 
     ASSERT_DOUBLE_EQ(2.0, vr[0]);
     ASSERT_DOUBLE_EQ(4.0, vr[1]);
     ASSERT_DOUBLE_EQ(6.0, vr[2]);
+
+    ASSERT_DOUBLE_EQ(2.0, vr1[0]);
+    ASSERT_DOUBLE_EQ(4.0, vr1[1]);
+    ASSERT_DOUBLE_EQ(6.0, vr1[2]);
+}
+
+TEST(VecOpsTests, SizedVecScalarDivOpTest) {
+    double alpha = 2.0;
+    auto v1 = lalib::SizedVec<double, 3>({1.0, 2.0, 3.0});
+
+    auto vr = v1 / alpha;
+
+    ASSERT_DOUBLE_EQ(0.5, vr[0]);
+    ASSERT_DOUBLE_EQ(1.0, vr[1]);
+    ASSERT_DOUBLE_EQ(1.5, vr[2]);
 }
 
 TEST(VecOpsTests, DynVecAxpyTest) {
@@ -175,10 +191,30 @@ TEST(VecOpsTests, DynVecScalarScaleOpTest) {
     auto v1 = lalib::DynVec<double>({1.0, 2.0, 3.0, 2.0, 4.0});
 
     auto vr = alpha * v1;
+    auto vr1 = v1 * alpha;
 
     ASSERT_DOUBLE_EQ(3.0, vr[0]);
     ASSERT_DOUBLE_EQ(6.0, vr[1]);
     ASSERT_DOUBLE_EQ(9.0, vr[2]);
     ASSERT_DOUBLE_EQ(6.0, vr[3]);
     ASSERT_DOUBLE_EQ(12.0, vr[4]);
+
+    ASSERT_DOUBLE_EQ(3.0, vr1[0]);
+    ASSERT_DOUBLE_EQ(6.0, vr1[1]);
+    ASSERT_DOUBLE_EQ(9.0, vr1[2]);
+    ASSERT_DOUBLE_EQ(6.0, vr1[3]);
+    ASSERT_DOUBLE_EQ(12.0, vr1[4]);
+}
+
+TEST(VecOpsTests, DynVecScalarDivOpTest) {
+    double alpha = 3.0;
+    auto v1 = lalib::DynVec<double>({1.0, 2.0, 3.0, 2.0, 4.0});
+
+    auto vr = v1 / alpha;
+
+    ASSERT_DOUBLE_EQ(1.0 / 3.0, vr[0]);
+    ASSERT_DOUBLE_EQ(2.0 / 3.0, vr[1]);
+    ASSERT_DOUBLE_EQ(1.0, vr[2]);
+    ASSERT_DOUBLE_EQ(2.0 / 3.0, vr[3]);
+    ASSERT_DOUBLE_EQ(4.0 / 3.0, vr[4]);
 }


### PR DESCRIPTION
# Overview
This pull request introduces some scalar-vector operations and their associated operator overloads.
The added operations are listed below.
* commutative of scalar-vector multiplication
* vector-scalar division

This update increments the minor version number.