### PR TITLE
Change to access LAPACK API through `lapacke.h`

### DIFF
--- a/.github/workflows/cmake_lapack_backend.yml
+++ b/.github/workflows/cmake_lapack_backend.yml
@@ -27,7 +27,7 @@ jobs:
       run: sudo apt-get install -y libgtest-dev libgmock-dev
 
     - name: Install OpenBLAS
-      run: sudo apt-get install -y libopenblas-dev liblapack-dev
+      run: sudo apt-get install -y libopenblas-dev liblapack-dev liblapacke-dev
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(lalib VERSION 0.2.2 LANGUAGES C CXX)
+project(lalib VERSION 0.2.3 LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED True)

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ WORKDIR /tmp/cmake-3.21.1
 RUN export CC=gcc-10 && export CXX=g++-10 \
 	&& ./bootstrap -- -DCMAKE_USE_OPENSSL=OFF && make && make install
 
-RUN apt-get install -y libopenblas-dev liblapack-dev
+RUN apt-get install -y libopenblas-dev liblapack-dev liblapacke-dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,5 +8,12 @@ services:
       - type: bind
         source: './'
         target: '/home/lalib'
+    command: >
+      bash -c "cd /home/lalib && 
+      cmake -B ../build_gcc10 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10 -DLALIB_BACKEND=Internal &&
+      cmake -B ../build_gcc10_blas -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10 -DLALIB_BACKEND=BLAS &&
+      cmake -B ../build_gcc10_lapack -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10 -DLALIB_BACKEND=LAPACK &&
+      cmake -B ../build_gcc10_gpu -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10 -DLALIB_BACKEND=Accelerator &&
+      bash"
     tty: true
     stdin_open: true

--- a/include/mat/dyn_mat.hpp
+++ b/include/mat/dyn_mat.hpp
@@ -7,6 +7,8 @@ namespace lalib {
 template<typename T>
 struct DynMat {
 public:
+    using ElemType = T;
+
     // ==== Initializations ==== //
 
     /// @brief Create a sized matrix with given array with copy.

--- a/include/mat/sized_mat.hpp
+++ b/include/mat/sized_mat.hpp
@@ -13,6 +13,8 @@ namespace lalib {
 template<typename T, size_t N, size_t M>
 struct SizedMat {
 public:
+    using ElemType = T;
+    
     // ==== Initializations ==== //
 
     /// @brief Create a sized matrix with given array with copy.

--- a/include/solver/internal/tdma.hpp
+++ b/include/solver/internal/tdma.hpp
@@ -5,23 +5,26 @@
 namespace lalib::solver::__internal {
 
 template<typename T>
-requires std::floating_point<T>
-auto tdma(size_t n, const T* dl, const T* d, const T* du, const T* b, T* x) -> T* {
-    std::vector<T> p, q;
-    p.reserve(n);
-    q.reserve(n);
+requires ::std::floating_point<T>
+auto tdma(size_t n, size_t nrow, const T* dl, const T* d, const T* du, const T* b, T* x) -> T* {
+    for (auto k = 0u; k < nrow; ++k) {
+        std::vector<T> p, q;
+        p.reserve(n);
+        q.reserve(n);
 
-    p.emplace_back(- du[0] / d[0]);
-    q.emplace_back(b[0] / d[0]);
-    for (auto i = 1u; i < n - 1; ++i) {
-        auto denom = (d[i] + dl[i - 1] * p[i - 1]);
-        p.emplace_back(- du[i] / denom);
-        q.emplace_back((b[i] - dl[i - 1] * q[i - 1]) / denom);
-    }
+        p.emplace_back(- du[0] / d[0]);
+        q.emplace_back(b[k] / d[0]);
+        for (auto i = 1u; i < n - 1; ++i) {
+            auto denom = (d[i] + dl[i - 1] * p[i - 1]);
+            p.emplace_back(- du[i] / denom);
+            q.emplace_back((b[k + i * nrow] - dl[i - 1] * q[i - 1]) / denom);
+        }
 
-    x[n - 1] = (b[n - 1] - dl[n - 2] * q[n - 2]) / (d[n - 1] + dl[n - 2] * p[n - 2]);
-    for (int32_t i = n - 2; i >= 0; --i) {
-        x[i] = p[i] * x[i + 1] + q[i];
+        auto tail = n - 1;
+        x[k + tail * nrow] = (b[k + tail * nrow] - dl[tail - 1] * q[tail - 1]) / (d[tail] + dl[tail - 1] * p[tail - 1]);
+        for (int32_t i = tail - 1; i >= 0; --i) {
+            x[k + i * nrow] = p[i] * x[k + (i + 1) * nrow] + q[i];
+        }
     }
     return x;
 }

--- a/include/solver/lapack/gtsv.hpp
+++ b/include/solver/lapack/gtsv.hpp
@@ -3,43 +3,56 @@
 #include <cstddef>
 #include <complex>
 
+#include <lapacke.h>
+
 namespace lalib::solver::__lapack {
     
-extern "C" {
-extern void sgtsv_(const int32_t* n, const int32_t* nrow, float* dl, float* d, float* du, float* b, const int32_t* ldb, int32_t* info);
-extern void dgtsv_(const int32_t* n, const int32_t* nrow, double* dl, double* d, double* du, double* b, const int32_t* ldb, int32_t* info);
-extern void cgtsv_(const int32_t* n, const int32_t* nrow, void* dl, void* d, void* du, void* b, const int32_t* ldb, int32_t* info);
-extern void zgtsv_(const int32_t* n, const int32_t* nrow, void* dl, void* d, void* du, void* b, const int32_t* ldb, int32_t* info);
-}
-
+/// @brief 
+/// @tparam T 
+/// @param n 
+/// @param nrhs 
+/// @param dl 
+/// @param d 
+/// @param du 
+/// @param b 
+/// @param ldb  In row major layout, the number of columns, otherwise, the number of rows.
+/// @return 
 template<typename T>
-auto gtsv(int32_t n, int32_t nrow, T* dl, T* d, T* du, T* b, int32_t ldb) -> int32_t = delete;
+auto gtsv(int32_t n, int32_t nrhs, T* dl, T* d, T* du, T* b, int32_t ldb) -> int32_t = delete;
 
 template<>
-auto gtsv<float>(int32_t n, int32_t nrow, float* dl, float* d, float* du, float* b, int32_t ldb) -> int32_t {
-    int32_t info;
-    sgtsv_(&n, &nrow, dl, d, du, b, &ldb, &info);
+auto gtsv<float>(int32_t n, int32_t nrhs, float* dl, float* d, float* du, float* b, int32_t ldb) -> int32_t {
+    auto info = LAPACKE_sgtsv(LAPACK_ROW_MAJOR, n, nrhs, dl, d, du, b, ldb);
     return info;
 }
 
 template<>
-auto gtsv<double>(int32_t n, int32_t nrow, double* dl, double* d, double* du, double* b, int32_t ldb) -> int32_t {
-    int32_t info;
-    dgtsv_(&n, &nrow, dl, d, du, b, &ldb, &info);
+auto gtsv<double>(int32_t n, int32_t nrhs, double* dl, double* d, double* du, double* b, int32_t ldb) -> int32_t {
+    auto info = LAPACKE_dgtsv(LAPACK_ROW_MAJOR, n, nrhs, dl, d, du, b, ldb);
     return info;
 }
 
 template<>
-auto gtsv<std::complex<float>>(int32_t n, int32_t nrow, std::complex<float>* dl, std::complex<float>* d, std::complex<float>* du, std::complex<float>* b, int32_t ldb) -> int32_t {
-    int32_t info;
-    cgtsv_(&n, &nrow, dl, d, du, b, &ldb, &info);
+auto gtsv<std::complex<float>>(int32_t n, int32_t nrhs, std::complex<float>* dl, std::complex<float>* d, std::complex<float>* du, std::complex<float>* b, int32_t ldb) -> int32_t {
+    auto info = LAPACKE_cgtsv(LAPACK_ROW_MAJOR, n, nrhs, 
+        reinterpret_cast<float __complex__ *>(dl), 
+        reinterpret_cast<float __complex__ *>(d), 
+        reinterpret_cast<float __complex__ *>(du), 
+        reinterpret_cast<float __complex__ *>(b), 
+        ldb
+    );
     return info;
 }
 
 template<>
-auto gtsv<std::complex<double>>(int32_t n, int32_t nrow, std::complex<double>* dl, std::complex<double>* d, std::complex<double>* du, std::complex<double>* b, int32_t ldb) -> int32_t {
-    int32_t info;
-    zgtsv_(&n, &nrow, dl, d, du, b, &ldb, &info);
+auto gtsv<std::complex<double>>(int32_t n, int32_t nrhs, std::complex<double>* dl, std::complex<double>* d, std::complex<double>* du, std::complex<double>* b, int32_t ldb) -> int32_t {
+    auto info = LAPACKE_zgtsv(LAPACK_ROW_MAJOR, n, nrhs, 
+        reinterpret_cast<double __complex__ *>(dl), 
+        reinterpret_cast<double __complex__ *>(d), 
+        reinterpret_cast<double __complex__ *>(du), 
+        reinterpret_cast<double __complex__ *>(b), 
+        ldb
+    );
     return info;
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -31,7 +31,12 @@ gtest_discover_tests(mat_vec_ops_test)
 
 ## Solvers
 add_executable(tri_diag_test solver/tri_diag.cc)
-target_link_libraries(tri_diag_test PRIVATE ${BLAS_LIBRARIES} ${OpenMP_CXX_LIBRARIES} GTest::GTest GTest::Main)
+target_link_libraries(tri_diag_test PRIVATE 
+    $<$<BOOL:${LAPACK_FOUND}>:LAPACK::LAPACK> 
+    $<$<BOOL:${LAPACK_FOUND}>:-llapacke>
+    ${BLAS_LIBRARIES} ${OpenMP_CXX_LIBRARIES} 
+    GTest::GTest GTest::Main
+)
 gtest_discover_tests(tri_diag_test)
 
 

--- a/test/solver/tri_diag.cc
+++ b/test/solver/tri_diag.cc
@@ -1,5 +1,5 @@
-#include "../../include/solver/tri_diag.hpp"
 #include <gtest/gtest.h>
+#include "../../include/solver/tri_diag.hpp"
 
 TEST(TriDiagSolverTests, SizedLinearSolverTest) {
     auto mat = lalib::SizedTriDiagMat<double, 4>(
@@ -37,4 +37,64 @@ TEST(TriDiagSolverTests, DynLinearSolverTest) {
     EXPECT_DOUBLE_EQ(2.0, rhs[1]);
     EXPECT_DOUBLE_EQ(3.0, rhs[2]);
     EXPECT_DOUBLE_EQ(4.0, rhs[3]);
+}
+
+TEST(TriDiagSolverTests, SizedMatLinearSolverTest) {
+    auto mat = lalib::SizedTriDiagMat<double, 4>(
+        { 1.0, 1.0, 1.0 },
+        { 2.0, 2.0, 2.0, 2.0 },
+        { 1.0, 1.0, 1.0 }
+    );
+    auto rhs = lalib::SizedMat<double, 4, 3>({ 
+        4.0, 2.0, 8.0,
+        8.0, 4.0, 16.0,
+        12.0, 6.0, 24.0,
+        11.0, 5.5, 22.0
+    });
+    auto solver = lalib::solver::TriDiag(mat);
+
+    solver.solve_linear(rhs, rhs);
+
+    EXPECT_DOUBLE_EQ(1.0, rhs(0, 0));
+    EXPECT_DOUBLE_EQ(2.0, rhs(1, 0));
+    EXPECT_DOUBLE_EQ(3.0, rhs(2, 0));
+    EXPECT_DOUBLE_EQ(4.0, rhs(3, 0));
+    EXPECT_DOUBLE_EQ(0.5, rhs(0, 1));
+    EXPECT_DOUBLE_EQ(1.0, rhs(1, 1));
+    EXPECT_DOUBLE_EQ(1.5, rhs(2, 1));
+    EXPECT_DOUBLE_EQ(2.0, rhs(3, 1));
+    EXPECT_DOUBLE_EQ(2.0, rhs(0, 2));
+    EXPECT_DOUBLE_EQ(4.0, rhs(1, 2));
+    EXPECT_DOUBLE_EQ(6.0, rhs(2, 2));
+    EXPECT_DOUBLE_EQ(8.0, rhs(3, 2));
+}
+
+TEST(TriDiagSolverTests, DynMatLinearSolverTest) {
+    auto mat = lalib::DynTriDiagMat<double>(
+        { 1.0, 1.0, 1.0 },
+        { 2.0, 2.0, 2.0, 2.0 },
+        { 1.0, 1.0, 1.0 }
+    );
+    auto rhs = lalib::DynMat<double>({ 
+        4.0, 2.0, 8.0,
+        8.0, 4.0, 16.0,
+        12.0, 6.0, 24.0,
+        11.0, 5.5, 22.0
+    }, 4, 3);
+    auto solver = lalib::solver::TriDiag(mat);
+
+    solver.solve_linear(rhs, rhs);
+
+    EXPECT_DOUBLE_EQ(1.0, rhs(0, 0));
+    EXPECT_DOUBLE_EQ(2.0, rhs(1, 0));
+    EXPECT_DOUBLE_EQ(3.0, rhs(2, 0));
+    EXPECT_DOUBLE_EQ(4.0, rhs(3, 0));
+    EXPECT_DOUBLE_EQ(0.5, rhs(0, 1));
+    EXPECT_DOUBLE_EQ(1.0, rhs(1, 1));
+    EXPECT_DOUBLE_EQ(1.5, rhs(2, 1));
+    EXPECT_DOUBLE_EQ(2.0, rhs(3, 1));
+    EXPECT_DOUBLE_EQ(2.0, rhs(0, 2));
+    EXPECT_DOUBLE_EQ(4.0, rhs(1, 2));
+    EXPECT_DOUBLE_EQ(6.0, rhs(2, 2));
+    EXPECT_DOUBLE_EQ(8.0, rhs(3, 2));
 }


### PR DESCRIPTION
# Overview
This pull request modifies the approach to access the Fortran LAPACK API.
The update now utilizes `lapacke.h` for the API access.
According to this update, the Dockerfile is updated to install lapacke-related interfaces.

The `docker-compose.yml` is also updated to predefine the multiple build tree to test for the multiple build options.