### PR TITLE
Add some functions for general matrix multiply ( BLAS-level 3 )

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(lalib VERSION 0.2.7 LANGUAGES C CXX)
+project(lalib VERSION 0.2.8 LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED True)

--- a/include/ops/mat_mat_ops.hpp
+++ b/include/ops/mat_mat_ops.hpp
@@ -1,0 +1,102 @@
+#pragma once
+#ifndef LALIB_MAT_MAT_OPS_HPP
+#define LALIB_MAT_MAT_OPS_HPP
+
+#include "mat_mat_ops_core.hpp"
+#include "../mat/sized_mat.hpp"
+#include "../mat/dyn_mat.hpp"
+#include "../vec/sized_vec.hpp"
+#include "../vec/dyn_vec.hpp"
+#include <cassert>
+
+namespace lalib {
+
+template<typename T, size_t N, size_t M, size_t L>
+inline auto mul(T alpha, const SizedMat<T, N, L>& a, const SizedMat<T, L, M>& b, T beta, SizedMat<T, N, M>& c) noexcept -> SizedMat<T, N, M>& {
+    mul_core(N, M, L, alpha, a.data(), b.data(), beta, c.data());
+    return c;
+}
+
+template<typename T, size_t N, size_t M, size_t L>
+inline auto mul(T alpha, const DynMat<T>& a, const SizedMat<T, L, M>& b, T beta, SizedMat<T, N, M>& c) noexcept -> SizedMat<T, N, M>& {
+    assert(a.shape().first == N);
+    assert(a.shape().second == L);
+    mul_core(N, M, L, alpha, a.data(), b.data(), beta, c.data());
+    return c;
+}
+
+template<typename T, size_t N, size_t M, size_t L>
+inline auto mul(T alpha, const SizedMat<T, N, L>& a, const DynMat<T>& b, T beta, SizedMat<T, N, M>& c) noexcept -> SizedMat<T, N, M>& {
+    assert(b.shape().first == L);
+    assert(b.shape().second == M);
+    mul_core(N, M, L, alpha, a.data(), b.data(), beta, c.data());
+    return c;
+}
+
+template<typename T, size_t N, size_t M>
+inline auto mul(T alpha, const DynMat<T>& a, const DynMat<T>& b, T beta, SizedMat<T, N, M>& c) noexcept -> SizedMat<T, N, M>& {
+    auto l = a.shape().second;
+    assert(a.shape().first == N);
+    assert(b.shape().second == M);
+    assert(a.shape().second == b.shape().first);
+    mul_core(N, M, l, alpha, a.data(), b.data(), beta, c.data());
+    return c;
+}
+
+template<typename T, size_t N, size_t M, size_t L>
+inline auto mul(T alpha, const SizedMat<T, N, L>& a, const SizedMat<T, L, M>& b, T beta, DynMat<T>& c) noexcept -> DynMat<T>& {
+    assert(c.shape().frist == N);
+    assert(c.shape().second == M);
+    mul_core(N, M, L, alpha, a.data(), b.data(), beta, c.data());
+    return c;
+}
+
+template<typename T, size_t M, size_t L>
+inline auto mul(T alpha, const DynMat<T>& a, const SizedMat<T, L, M>& b, T beta, DynMat<T>& c) noexcept -> DynMat<T>& {
+    auto n = a.shape().first;
+    assert(a.shape().first == c.shape().first);
+    assert(b.shape().second == c.shape().second);
+    assert(a.shape().second == L);
+    mul_core(n, M, L, alpha, a.data(), b.data(), beta, c.data());
+    return c;
+}
+
+template<typename T, size_t N, size_t L>
+inline auto mul(T alpha, const SizedMat<T, N, L>& a, const DynMat<T>& b, T beta, DynMat<T>& c) noexcept -> DynMat<T>& {
+    auto m = b.shape().second;
+    assert(b.shape().first == L);
+    assert(a.shape().first == c.shape().first);
+    assert(b.shape().second == c.shape().second);
+    mul_core(N, m, L, alpha, a.data(), b.data(), beta, c.data());
+    return c;
+}
+
+template<typename T>
+inline auto mul(T alpha, const DynMat<T>& a, const DynMat<T>& b, T beta, DynMat<T>& c) noexcept -> DynMat<T>& {
+    auto [n, m] = c.shape();
+    auto l = a.shape().second;
+    assert(a.shape().first == n);
+    assert(b.shape().second == m);
+    assert(a.shape().second == b.shape().first);
+    mul_core(n, m, l, alpha, a.data(), b.data(), beta, c.data());
+    return c;
+}
+
+
+template<typename T, size_t N, size_t M, size_t L>
+inline auto operator*(const SizedMat<T, N, L>& a, const SizedMat<T, L, M>& b) noexcept -> SizedMat<T, N, M> {
+    auto mr = lalib::SizedMat<T, N, M>::uninit();
+    mul(1.0, a, b, 0.0, mr);
+    return mr;
+}
+
+template<typename T>
+inline auto operator*(const DynMat<T>& a, const DynMat<T>& b) noexcept -> DynMat<T> {
+    auto mr = lalib::DynMat<T>::uninit(a.shape().first, b.shape().second);
+    mul(1.0, a, b, 0.0, mr);
+    return mr;
+}
+
+}
+
+#endif

--- a/include/ops/mat_mat_ops_core.hpp
+++ b/include/ops/mat_mat_ops_core.hpp
@@ -1,0 +1,93 @@
+/**
+ * @file mat_mat_ops_core.hpp
+ * @author Kohei KONISHI 
+ * @brief  This file defines the BLAS level 2 - equivalent APIs.
+ * @version 0.1
+ * @date 2024-01-15
+ * 
+ * @copyright Copyright (c) 2024
+ * 
+ */
+
+#pragma once
+#ifndef LALIB_MAT_MAT_OPS_CORE_HPP
+#define LALIB_MAT_MAT_OPS_CORE_HPP
+
+#include <cstddef>
+#include <cstdint>
+
+#ifdef LALIB_BLAS_BACKEND
+#include <cblas.h>
+#endif
+
+namespace lalib {
+
+template<typename T>
+inline auto __mul_core_simd(size_t n, size_t m, size_t o, T alpha, const T* mata, const T* matb, T beta, T* matc) {
+    if (mata == matc || matb == matc) {
+        auto tmpc = std::make_unique<T[]>(n * m);
+        for (auto i = 0u; i < n; ++i) {
+            for (auto j = 0u; j < m; ++j) {
+                tmpc[i * m + j] = beta * matc[i * m + j];
+                for (auto k = 0u; k < o; ++k) {
+                    tmpc[i * m + j] += alpha * mata[i * o + k] * matb[k * m + j];
+                }
+            }
+        }
+        std::copy(tmpc.get(), tmpc.get() + n * m, matc);
+    } else {
+        for (auto i = 0u; i < n; ++i) {
+            for (auto j = 0u; j < m; ++j) {
+                matc[i * m + j] *= beta;
+                for (auto k = 0u; k < o; ++k) {
+                    matc[i * m + j] += alpha * mata[i * o + k] * matb[k * m + j];
+                }
+            }
+        }
+    }
+    return matc;
+}
+
+template<typename T>
+inline auto mul_core(size_t n, size_t m, size_t o, T alpha, const T* mata, const T* matb, T beta, T* matc) noexcept -> T* {
+    __mul_core_simd(n, m, o, alpha, mata, matb, beta, matc);
+    return matc;
+}
+
+template<>
+inline auto mul_core<float>(size_t n, size_t m, size_t l, float alpha, const float* mata, const float* matb, float beta, float* matc) noexcept -> float* {
+    #if defined(LALIB_BLAS_BACKEND)
+    if (mata == matc || matb == matc) {
+        auto tmp = std::make_unique<float[]>(n * m);
+        std::copy(matc, matc + n * m, tmp.get());
+        cblas_sgemm(CBLAS_LAYOUT::CblasRowMajor, CBLAS_TRANSPOSE::CblasNoTrans, CBLAS_TRANSPOSE::CblasNoTrans, n, m, l, alpha, mata, l, matb, m, beta, tmp.get(), n);
+        std::copy(tmp.get(), tmp.get() + n * m, matc);
+    } else {
+        cblas_sgemm(CBLAS_LAYOUT::CblasRowMajor, CBLAS_TRANSPOSE::CblasNoTrans, CBLAS_TRANSPOSE::CblasNoTrans, n, m, l, alpha, mata, l, matb, m, beta, matc, n);
+    }
+    #else
+    __mul_core_simd(n, m, l, alpha, mata, matb, beta, matc);
+    #endif
+    return matc;
+}
+
+template<>
+inline auto mul_core<double>(size_t n, size_t m, size_t l, double alpha, const double* mata, const double* matb, double beta, double* matc) noexcept -> double* {
+    #if defined(LALIB_BLAS_BACKEND)
+    if (mata == matc || matb == matc) {
+        auto tmp = std::make_unique<double[]>(n * m);
+        std::copy(matc, matc + n * m, tmp.get());
+        cblas_dgemm(CBLAS_LAYOUT::CblasRowMajor, CBLAS_TRANSPOSE::CblasNoTrans, CBLAS_TRANSPOSE::CblasNoTrans, n, m, l, alpha, mata, l, matb, m, beta, tmp.get(), n);
+        std::copy(tmp.get(), tmp.get() + n * m, matc);
+    } else {
+        cblas_dgemm(CBLAS_LAYOUT::CblasRowMajor, CBLAS_TRANSPOSE::CblasNoTrans, CBLAS_TRANSPOSE::CblasNoTrans, n, m, l, alpha, mata, l, matb, m, beta, matc, n);
+    }
+    #else
+    __mul_core_simd(n, m, l, alpha, mata, matb, beta, matc);
+    #endif
+    return matc;
+}
+
+}
+
+#endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -28,6 +28,11 @@ add_executable(mat_vec_ops_test ops/mat_vec_ops.cc)
 target_link_libraries(mat_vec_ops_test PRIVATE ${BLAS_LIBRARIES} ${OpenMP_CXX_LIBRARIES} GTest::GTest GTest::Main)
 gtest_discover_tests(mat_vec_ops_test)
 
+## Matrix-Matrix Operations
+add_executable(mat_mat_ops_test ops/mat_mat_ops.cc)
+target_link_libraries(mat_mat_ops_test PRIVATE ${BLAS_LIBRARIES} ${OpenMP_CXX_LIBRARIES} GTest::GTest GTest::Main)
+gtest_discover_tests(mat_mat_ops_test)
+
 
 ## Solvers
 add_executable(tri_diag_test solver/tri_diag.cc)

--- a/test/ops/mat_mat_ops.cc
+++ b/test/ops/mat_mat_ops.cc
@@ -1,0 +1,80 @@
+#include <gtest/gtest.h>
+#include "../..//include/ops/mat_mat_ops.hpp"
+#include <iostream>
+
+TEST(MatMatOpsTests, SizedMatSizedMatMulTest) {
+    auto m1 = lalib::SizedMat<double, 2, 3>({
+        1.0, 3.0, 5.0,
+        2.0, 4.0, 6.0
+    });
+    auto m2 = lalib::SizedMat<double, 3, 2>({ 
+        1.0, 2.0,
+        2.0, 3.0,
+        3.0, 4.0
+    });
+    auto m3 = lalib::SizedMat<double, 2, 2>::filled(1.0);
+    auto alpha = 2.0;
+    auto beta = 3.0;
+
+    lalib::mul(2.0, m1, m2, 3.0, m3);
+    auto m4 = m1 * m2;
+
+    ASSERT_DOUBLE_EQ(alpha * 22.0 + beta, m3(0, 0));
+    ASSERT_DOUBLE_EQ(alpha * 31.0 + beta, m3(0, 1));
+    ASSERT_DOUBLE_EQ(alpha * 28.0 + beta, m3(1, 0));
+    ASSERT_DOUBLE_EQ(alpha * 40.0 + beta, m3(1, 1));
+
+    ASSERT_DOUBLE_EQ(22.0, m4(0, 0));
+    ASSERT_DOUBLE_EQ(31.0, m4(0, 1));
+    ASSERT_DOUBLE_EQ(28.0, m4(1, 0));
+    ASSERT_DOUBLE_EQ(40.0, m4(1, 1));
+}
+
+
+TEST(MatMatOpsTests, DynMatDynMatMulTest) {
+    auto m1 = lalib::DynMat<double>({
+        1.0, 3.0, 5.0,
+        2.0, 4.0, 6.0
+    }, 2, 3);
+    auto m2 = lalib::DynMat<double>({ 
+        1.0, 2.0,
+        2.0, 3.0,
+        3.0, 4.0
+    }, 3, 2);
+    auto m3 = lalib::DynMat<double>::filled(1.0, 2, 2);
+    auto alpha = 2.0;
+    auto beta = 3.0;
+
+    lalib::mul(2.0, m1, m2, 3.0, m3);
+    auto m4 = m1 * m2;
+
+    ASSERT_DOUBLE_EQ(alpha * 22.0 + beta, m3(0, 0));
+    ASSERT_DOUBLE_EQ(alpha * 31.0 + beta, m3(0, 1));
+    ASSERT_DOUBLE_EQ(alpha * 28.0 + beta, m3(1, 0));
+    ASSERT_DOUBLE_EQ(alpha * 40.0 + beta, m3(1, 1));
+
+    ASSERT_DOUBLE_EQ(22.0, m4(0, 0));
+    ASSERT_DOUBLE_EQ(31.0, m4(0, 1));
+    ASSERT_DOUBLE_EQ(28.0, m4(1, 0));
+    ASSERT_DOUBLE_EQ(40.0, m4(1, 1));
+}
+
+TEST(MatMatOpsTests, SizedMatSizedMatMulAssignTest) {
+    auto m1 = lalib::SizedMat<double, 2, 2>({
+        1.0, 3.0,
+        2.0, 4.0
+    });
+    auto m2 = lalib::SizedMat<double, 2, 2>({ 
+        1.0, 2.0,
+        2.0, 3.0
+    });
+    auto alpha = 2.0;
+    auto beta = 3.0;
+
+    lalib::mul(2.0, m1, m2, 3.0, m1);
+
+    ASSERT_DOUBLE_EQ(alpha * 7.0 + beta * 1.0, m1(0, 0));
+    ASSERT_DOUBLE_EQ(alpha * 11.0 + beta * 3.0, m1(0, 1));
+    ASSERT_DOUBLE_EQ(alpha * 10.0 + beta * 2.0, m1(1, 0));
+    ASSERT_DOUBLE_EQ(alpha * 16.0 + beta * 4.0, m1(1, 1));
+}


### PR DESCRIPTION
# Overview
This pull request adds some functions to perform general matrix multiply ( compatible with `gemm` subroutines in BLAS level 3 ).

The other derived functions of matrix multiply functions defined in BLAS level 3 and the other BLAS level 3 function will be added in the future update.