### PR TITLE
Add Cholesky factorization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(lalib VERSION 0.4.0 LANGUAGES C CXX)
+project(lalib VERSION 0.5.0 LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED True)

--- a/include/lalib/mat/dyn_mat.hpp
+++ b/include/lalib/mat/dyn_mat.hpp
@@ -301,6 +301,131 @@ inline auto DynTriDiagMat<T>::data_du() noexcept -> T *
 {
     return this->_du.data();
 }
+
+
+/*  ################################  *
+    Dynamic Lower Triangular Matrix
+ *  ################################  */   
+
+template<typename T>
+struct DynLowerTriMat {
+    DynLowerTriMat(size_t n, std::vector<T>&& lower_elems) noexcept;
+
+    /// @brief Returns the shape of the tri-diagonal matrix
+    constexpr auto shape() const noexcept -> std::pair<size_t, size_t>;
+
+    constexpr auto operator()(size_t i, size_t j) const -> const T&;
+    constexpr auto operator()(size_t i, size_t j) -> T&;
+
+    auto lower_data() const noexcept -> const T*;
+    auto lower_data() noexcept -> T*;
+
+private:
+    size_t _n;
+    std::vector<T> _lower_elems;
+};
+
+template<typename T>
+DynLowerTriMat<T>::DynLowerTriMat(size_t n, std::vector<T>&& lower_elems) noexcept:
+    _n(n),
+    _lower_elems(std::move(lower_elems))
+{}
+
+template<typename T>
+constexpr auto DynLowerTriMat<T>::shape() const noexcept -> std::pair<size_t, size_t> {
+    return std::make_pair(this->_n, this->_n);
+}
+
+template<typename T>
+constexpr auto DynLowerTriMat<T>::operator()(size_t i, size_t j) const -> const T& {
+    if (i < j) { std::swap(i, j); }
+    return this->_lower_elems[i * (i + 1) / 2 + j];
+}
+
+template<typename T>
+constexpr auto DynLowerTriMat<T>::operator()(size_t i, size_t j) -> T& {
+    if (i < j) { std::swap(i, j); }
+    return this->_lower_elems[i * (i + 1) / 2 + j];
+}
+
+template<typename T>
+auto DynLowerTriMat<T>::lower_data() const noexcept -> const T* {
+    return this->_lower_elems.data();
+}
+
+template<typename T>
+auto DynLowerTriMat<T>::lower_data() noexcept -> T* {
+    return this->_lower_elems.data();
+}
+
+
+/*  ############################  *
+    Dynamic Hermiteian Matrix
+ *  ############################  */   
+
+template<typename T>
+struct DynHermiteMat {
+    DynHermiteMat(size_t n, std::vector<T>&& lower_elems) noexcept;
+
+    /// @brief  Creates a lower triangular matrix by truncating the upper triangular elements.
+    /// @warning    Don't use this instance after calling this function because underlaying element vector will be moved.
+    auto into_lower_mat() noexcept -> DynLowerTriMat<T>;
+
+    /// @brief Returns the shape of the tri-diagonal matrix
+    constexpr auto shape() const noexcept -> std::pair<size_t, size_t>;
+
+    constexpr auto operator()(size_t i, size_t j) const -> const T&;
+    constexpr auto operator()(size_t i, size_t j) -> T&;
+
+    auto lower_data() const noexcept -> const T*;
+    auto lower_data() noexcept -> T*;
+
+private:
+    size_t _n;
+    std::vector<T> _lower_elems;
+};
+
+template<typename T>
+DynHermiteMat<T>::DynHermiteMat(size_t n, std::vector<T>&& lower_elems) noexcept:
+    _n(n),
+    _lower_elems(std::move(lower_elems))
+{}
+
+
+template<typename T>
+auto DynHermiteMat<T>::into_lower_mat() noexcept -> DynLowerTriMat<T> {
+    auto lm = DynLowerTriMat<T>(this->_n, std::move(this->_lower_elems));
+    return lm;
+}
+
+template<typename T>
+constexpr auto DynHermiteMat<T>::shape() const noexcept -> std::pair<size_t, size_t> {
+    return std::make_pair(this->_n, this->_n);
+}
+
+template<typename T>
+constexpr auto DynHermiteMat<T>::operator()(size_t i, size_t j) const -> const T& {
+    if (i < j) { std::swap(i, j); }
+    return this->_lower_elems[i * (i + 1) / 2 + j];
+}
+
+template<typename T>
+constexpr auto DynHermiteMat<T>::operator()(size_t i, size_t j) -> T& {
+    if (i < j) { std::swap(i, j); }
+    return this->_lower_elems[i * (i + 1) / 2 + j];
+}
+
+template<typename T>
+auto DynHermiteMat<T>::lower_data() const noexcept -> const T* {
+    return this->_lower_elems.data();
+}
+
+template<typename T>
+auto DynHermiteMat<T>::lower_data() noexcept -> T* {
+    return this->_lower_elems.data();
+}
+
+
 }
 
 #endif

--- a/include/lalib/mat/sized_mat.hpp
+++ b/include/lalib/mat/sized_mat.hpp
@@ -295,6 +295,130 @@ inline auto SizedTriDiagMat<T, N>::data_du() noexcept -> T *
 {
     return this->_du.data();
 }
+
+
+/*  ##############################  *
+    Sized Lower Triangular Matrix
+ *  ##############################  */   
+
+template<typename T, size_t N>
+struct SizedLowerTriMat {
+    SizedLowerTriMat(const std::array<T, N * (N + 1) / 2>& lower_elems) noexcept;
+
+
+    /// @brief Returns the shape of the tri-diagonal matrix
+    constexpr auto shape() const noexcept -> std::pair<size_t, size_t>;
+
+    constexpr auto operator()(size_t i, size_t j) const -> const T&;
+    constexpr auto operator()(size_t i, size_t j) -> T&;
+
+    auto lower_data() const noexcept -> const T*;
+    auto lower_data() noexcept -> T*;
+
+private:
+    std::array<T, N * (N + 1) / 2> _lower_elems;
+};
+
+template<typename T, size_t N>
+SizedLowerTriMat<T, N>::SizedLowerTriMat(const std::array<T, N * (N + 1) / 2>& lower_elems) noexcept:
+    _lower_elems(lower_elems)
+{}
+
+
+template<typename T, size_t N>
+constexpr auto SizedLowerTriMat<T, N>::shape() const noexcept -> std::pair<size_t, size_t> {
+    return std::make_pair(N, N);
+}
+
+template<typename T, size_t N>
+constexpr auto SizedLowerTriMat<T, N>::operator()(size_t i, size_t j) const -> const T& {
+    if (i < j) { std::swap(i, j); }
+    return this->_lower_elems[i * (i + 1) / 2 + j];
+}
+
+template<typename T, size_t N>
+constexpr auto SizedLowerTriMat<T, N>::operator()(size_t i, size_t j) -> T& {
+    if (i < j) { std::swap(i, j); }
+    return this->_lower_elems[i * (i + 1) / 2 + j];
+}
+
+template<typename T, size_t N>
+auto SizedLowerTriMat<T, N>::lower_data() const noexcept -> const T* {
+    return this->_lower_elems.data();
+}
+
+template<typename T, size_t N>
+auto SizedLowerTriMat<T, N>::lower_data() noexcept -> T* {
+    return this->_lower_elems.data();
+}
+
+
+/*  ############################  *
+    Sized Hermiteian Matrix
+ *  ############################  */   
+
+template<typename T, size_t N>
+struct SizedHermiteMat {
+    SizedHermiteMat(const std::array<T, N * (N + 1) / 2>& lower_elems) noexcept;
+
+    /// @brief  Creates a lower triangular matrix by truncating the upper triangular elements.
+    /// @warning    Don't use this instance after calling this function because underlaying element vector will be moved.
+    auto into_lower_mat() noexcept -> SizedLowerTriMat<T, N>;
+
+    /// @brief Returns the shape of the tri-diagonal matrix
+    constexpr auto shape() const noexcept -> std::pair<size_t, size_t>;
+
+    constexpr auto operator()(size_t i, size_t j) const -> const T&;
+    constexpr auto operator()(size_t i, size_t j) -> T&;
+
+    auto lower_data() const noexcept -> const T*;
+    auto lower_data() noexcept -> T*;
+
+private:
+    std::array<T, N * (N + 1) / 2> _lower_elems;
+};
+
+template<typename T, size_t N>
+SizedHermiteMat<T, N>::SizedHermiteMat(const std::array<T, N * (N + 1) / 2>& lower_elems) noexcept:
+    _lower_elems(lower_elems)
+{}
+
+
+template<typename T, size_t N>
+auto SizedHermiteMat<T, N>::into_lower_mat() noexcept -> SizedLowerTriMat<T, N> {
+    auto lm = SizedLowerTriMat<T, N>(std::move(this->_lower_elems));
+    return lm;
+}
+
+template<typename T, size_t N>
+constexpr auto SizedHermiteMat<T, N>::shape() const noexcept -> std::pair<size_t, size_t> {
+    return std::make_pair(N, N);
+}
+
+template<typename T, size_t N>
+constexpr auto SizedHermiteMat<T, N>::operator()(size_t i, size_t j) const -> const T& {
+    if (i < j) { std::swap(i, j); }
+    return this->_lower_elems[i * (i + 1) / 2 + j];
+}
+
+template<typename T, size_t N>
+constexpr auto SizedHermiteMat<T, N>::operator()(size_t i, size_t j) -> T& {
+    if (i < j) { std::swap(i, j); }
+    return this->_lower_elems[i * (i + 1) / 2 + j];
+}
+
+template<typename T, size_t N>
+auto SizedHermiteMat<T, N>::lower_data() const noexcept -> const T* {
+    return this->_lower_elems.data();
+}
+
+template<typename T, size_t N>
+auto SizedHermiteMat<T, N>::lower_data() noexcept -> T* {
+    return this->_lower_elems.data();
+}
+
+
+
 }
 
 #endif

--- a/include/lalib/ops/mat_mat_ops.hpp
+++ b/include/lalib/ops/mat_mat_ops.hpp
@@ -5,11 +5,108 @@
 #include "mat_mat_ops_core.hpp"
 #include "lalib/mat/sized_mat.hpp"
 #include "lalib/mat/dyn_mat.hpp"
-#include "lalib/vec/sized_vec.hpp"
-#include "lalib/vec/dyn_vec.hpp"
+#include "lalib/ops/vec_ops_core.hpp"
 #include <cassert>
 
 namespace lalib {
+
+// =============== //
+//  ADD            //
+// =============== //
+
+template<typename T, size_t N, size_t M>
+inline auto add(const SizedMat<T, N, M>& m1, const SizedMat<T, N, M>& m2, SizedMat<T, N, M>& mr) noexcept -> SizedMat<T, N, M>& {
+    add_core(m1.data(), m2.data(), mr.data(), m1.shape().first * m1.shape().second);
+    return mr;
+}
+
+template<typename T, size_t N, size_t M>
+inline auto add(const SizedMat<T, N, M>& m1, const DynMat<T>& m2, SizedMat<T, N, M>& mr) noexcept -> SizedMat<T, N, M>& {
+    assert(m1.shape() == m2.shape());
+    add_core(m1.data(), m2.data(), mr.data(), m1.shape().first * m1.shape().second);
+    return mr;
+}
+
+template<typename T, size_t N, size_t M>
+inline auto add(const DynMat<T>& m1, const SizedMat<T, N, M>& m2, SizedMat<T, N, M>& mr) noexcept -> SizedMat<T, N, M>& {
+    assert(m1.shape() == m2.shape());
+    add_core(m1.data(), m2.data(), mr.data(), m1.shape().first * m1.shape().second);
+    return mr;
+}
+
+template<typename T>
+inline auto add(const DynMat<T>& m1, const DynMat<T>& m2, DynMat<T>& mr) noexcept -> DynMat<T>& {
+    assert(m1.shape() == m2.shape());
+    assert(m1.shape() == mr.shape());
+    add_core(m1.data(), m2.data(), mr.data(), m1.shape().first * m1.shape().second);
+    return mr;
+}
+
+template<typename T, size_t N, size_t M>
+inline auto operator+(const SizedMat<T, N, M>& m1, const SizedMat<T, N, M>& m2) noexcept -> SizedMat<T, N, M> {
+    auto mr = SizedMat(m1);
+    add(m1, m2, mr);
+    return mr;
+}
+
+template<typename T>
+inline auto operator+(const DynMat<T>& m1, const DynMat<T>& m2) noexcept -> DynMat<T> {
+    auto mr = DynMat(m1);
+    add(m1, m2, mr);
+    return mr;
+}
+
+
+// =============== //
+//  SUB            //
+// =============== //
+
+template<typename T, size_t N, size_t M>
+inline auto sub(const SizedMat<T, N, M>& m1, const SizedMat<T, N, M>& m2, SizedMat<T, N, M>& mr) noexcept -> SizedMat<T, N, M>& {
+    sub_core(m1.data(), m2.data(), mr.data(), m1.shape().first * m1.shape().second);
+    return mr;
+}
+
+template<typename T, size_t N, size_t M>
+inline auto sub(const SizedMat<T, N, M>& m1, const DynMat<T>& m2, SizedMat<T, N, M>& mr) noexcept -> SizedMat<T, N, M>& {
+    assert(m1.shape() == m2.shape());
+    sub_core(m1.data(), m2.data(), mr.data(), m1.shape().first * m1.shape().second);
+    return mr;
+}
+
+template<typename T, size_t N, size_t M>
+inline auto sub(const DynMat<T>& m1, const SizedMat<T, N, M>& m2, SizedMat<T, N, M>& mr) noexcept -> SizedMat<T, N, M>& {
+    assert(m1.shape() == m2.shape());
+    sub_core(m1.data(), m2.data(), mr.data(), m1.shape().first * m1.shape().second);
+    return mr;
+}
+
+template<typename T>
+inline auto sub(const DynMat<T>& m1, const DynMat<T>& m2, DynMat<T>& mr) noexcept -> DynMat<T>& {
+    assert(m1.shape() == m2.shape());
+    assert(m1.shape() == mr.shape());
+    sub_core(m1.data(), m2.data(), mr.data(), m1.shape().first * m1.shape().second);
+    return mr;
+}
+
+template<typename T, size_t N, size_t M>
+inline auto operator-(const SizedMat<T, N, M>& m1, const SizedMat<T, N, M>& m2) noexcept -> SizedMat<T, N, M> {
+    auto mr = SizedMat(m1);
+    sub(m1, m2, mr);
+    return mr;
+}
+
+template<typename T>
+inline auto operator-(const DynMat<T>& m1, const DynMat<T>& m2) noexcept -> DynMat<T> {
+    auto mr = DynMat(m1);
+    sub(m1, m2, mr);
+    return mr;
+}
+
+
+// =============== //
+//  MUL            //
+// =============== //
 
 template<typename T, size_t N, size_t M, size_t L>
 inline auto mul(T alpha, const SizedMat<T, N, L>& a, const SizedMat<T, L, M>& b, T beta, SizedMat<T, N, M>& c) noexcept -> SizedMat<T, N, M>& {

--- a/include/lalib/solver/cholesky_factorization.hpp
+++ b/include/lalib/solver/cholesky_factorization.hpp
@@ -1,0 +1,145 @@
+#pragma once
+#include "lalib/mat/dyn_mat.hpp"
+#include "lalib/solver/lapack/potr.hpp"
+#ifndef LALIB_SOLVER_CHOLESKY_HPP
+#define LALIB_SOLVER_CHOLESKY_HPP
+
+#include "lalib/solver/internal/cholesky_decomposition.hpp"
+#include "lalib/type_traits.hpp"
+#include "lalib/mat.hpp"
+
+namespace lalib::solver {
+
+template<typename T>
+struct DynTriCholeskyFactorization {
+    DynTriCholeskyFactorization(lalib::DynHermiteMat<T>&& mat);
+
+	auto lower_matrix() const noexcept -> const lalib::DynLowerTriMat<T>&;
+
+    template<Vector V>
+    auto solve_linear(const V& rhs, V& rslt) const -> V&;
+
+    template<Matrix M>
+    auto solve_linear(const M& rhs, M& rslt) const -> M&;
+
+private:
+    size_t _n;
+    lalib::DynLowerTriMat<T> _data;
+};
+
+template<typename T>
+struct DynCholeskyFactorization {
+    DynCholeskyFactorization(lalib::DynMat<T>&& mat);
+
+	auto factor_matrix() const noexcept -> const lalib::DynMat<T>&;
+
+    template<Vector V>
+    auto solve_linear(const V& rhs, V& rslt) const -> V&;
+
+    template<Matrix M>
+    auto solve_linear(const M& rhs, M& rslt) const -> M&;
+
+private:
+    size_t _n;
+    lalib::DynMat<T> _data;
+};
+
+template<typename T>
+inline DynTriCholeskyFactorization<T>::DynTriCholeskyFactorization(lalib::DynHermiteMat<T>&& mat):
+    _n(mat.shape().first),
+    _data(mat.into_lower_mat())
+{ 
+    auto rslt = _internal_::cholesky_decomposition<T, _internal_::MemType::Triangle>(this->_n, this->_data.lower_data());
+
+	if (rslt != 0) {
+		throw std::runtime_error("[error] fail to decompose the given matrix into LL* matrices (exit with code: " + std::to_string(rslt) + ")");
+	}
+}
+
+
+template<typename T>
+inline auto DynTriCholeskyFactorization<T>::lower_matrix() const noexcept -> const lalib::DynLowerTriMat<T>& {
+	return this->_data;
+}
+
+
+template<typename T>
+template<Vector V>
+inline auto DynTriCholeskyFactorization<T>::solve_linear(const V& rhs, V& rslt) const -> V& {
+   	assert(this->_data.shape().first == rhs.size());
+
+	_internal_::cholesky_linear<double, _internal_::MemType::Triangle>
+		(rhs.size(), 1, this->_data.lower_data(), rhs.data(), rslt.data());
+	return rslt;
+}
+
+template<typename T>
+template<Matrix M>
+inline auto DynTriCholeskyFactorization<T>::solve_linear(const M& rhs, M& rslt) const -> M& {
+   	assert(this->_data.shape().first == rhs.shape().first);
+   	assert(rhs.shape().first == rhs.shape().first);
+   	assert(rhs.shape().second == rhs.shape().second);
+
+	_internal_::cholesky_linear<double, _internal_::MemType::Triangle>
+		(rhs.shape().first, rhs.shape().second, this->_data.lower_data(), rhs.data(), rslt.data());
+	return rslt;
+}
+
+template<typename T>
+inline DynCholeskyFactorization<T>::DynCholeskyFactorization(lalib::DynMat<T>&& mat):
+    _n(mat.shape().first),
+    _data(mat.into_lower_mat())
+{ 
+	#if defined LALIB_LAPACK_BACKEND
+	auto rslt = _lapack_::potrf(this->_n, this->_data.lower_data(), this->_n);
+	#else
+    auto rslt = _internal_::cholesky_decomposition<T, _internal_::MemType::Square>(this->_n, this->_data.lower_data());
+	#endif
+
+	if (rslt != 0) {
+		throw std::runtime_error("[error] fail to decompose the given matrix into LL* matrices (exit with code: " + std::to_string(rslt) + ")");
+	}
+}
+
+
+template<typename T>
+inline auto DynCholeskyFactorization<T>::factor_matrix() const noexcept -> const lalib::DynMat<T>& {
+	return this->_data;
+}
+
+
+template<typename T>
+template<Vector V>
+inline auto DynCholeskyFactorization<T>::solve_linear(const V& rhs, V& rslt) const -> V& {
+   	assert(this->_data.shape().first == rhs.size());
+
+	#if defined LALIB_LAPACK_BACKEND
+	rslt = rhs;
+	_lapack_::potrs(rhs.size(), 1, this->_data.lower_data(), rhs.size(), rslt.data(), rslt.size());
+	#else
+	_internal_::cholesky_linear<double, _internal_::MemType::Square>
+		(rhs.size(), 1, this->_data.lower_data(), rhs.data(), rslt.data());
+	#endif
+	return rslt;
+}
+
+template<typename T>
+template<Matrix M>
+inline auto DynCholeskyFactorization<T>::solve_linear(const M& rhs, M& rslt) const -> M& {
+   	assert(this->_data.shape().first == rhs.shape().first);
+   	assert(rhs.shape().first == rhs.shape().first);
+   	assert(rhs.shape().second == rhs.shape().second);
+
+	#if defined LALIB_LAPACK_BACKEND
+	rslt = rhs;
+	_lapack_::potrs(rhs.shape().first, rhs.shape().second, this->_data.lower_data(), this->_data.shape().first, rslt.data(), rslt.shape().first);
+	#else
+	_internal_::cholesky_linear<double, _internal_::MemType::Square>
+		(rhs.shape().first, rhs.shape().second, this->_data.lower_data(), rhs.data(), rslt.data());
+	#endif
+	return rslt;
+}
+
+}
+
+#endif

--- a/include/lalib/solver/cholesky_factorization.hpp
+++ b/include/lalib/solver/cholesky_factorization.hpp
@@ -1,12 +1,15 @@
 #pragma once
-#include "lalib/mat/dyn_mat.hpp"
-#include "lalib/solver/lapack/potr.hpp"
 #ifndef LALIB_SOLVER_CHOLESKY_HPP
 #define LALIB_SOLVER_CHOLESKY_HPP
 
+#include "lalib/mat/dyn_mat.hpp"
 #include "lalib/solver/internal/cholesky_decomposition.hpp"
 #include "lalib/type_traits.hpp"
 #include "lalib/mat.hpp"
+
+#if defined(LALIB_LAPACK_BACKEND)
+#include "lalib/solver/lapack/potr.hpp"
+#endif
 
 namespace lalib::solver {
 

--- a/include/lalib/solver/internal/cholesky_decomposition.hpp
+++ b/include/lalib/solver/internal/cholesky_decomposition.hpp
@@ -1,0 +1,76 @@
+#pragma once 
+#ifndef LALIB_SOLVER_INTERNAL_CHOLESKY_HPP
+#define LALIB_SOLVER_INTERNAL_CHOLESKY_HPP
+
+#include "lalib/mat.hpp"
+
+namespace lalib::solver::_internal_ {
+
+enum class MemType { Square, Triangle };
+
+template<MemType MType>
+inline constexpr auto index(size_t n, size_t i, size_t j) noexcept -> size_t;
+
+template<>
+inline constexpr auto index<MemType::Square>(size_t n, size_t i, size_t j) noexcept -> size_t {
+	return i * n + j;
+}
+
+template<>
+inline constexpr auto index<MemType::Triangle>(size_t, size_t i, size_t j) noexcept -> size_t {
+	return i * (i + 1) / 2 + j;
+}
+
+
+template<typename T, MemType MType>
+auto cholesky_decomposition(size_t n, double* l) -> int32_t {
+    for (auto i = 0u; i < n; ++i) {
+		for (auto j = 0u; j < i; ++j) {
+			for (auto k = 0u; k < j; ++k) { 
+				l[index<MType>(n, i, j)] -= l[index<MType>(n, i, k)] * l[index<MType>(n, j, k)]; 
+			}
+			l[index<MType>(n, i, j)] /= l[index<MType>(n, j, j)];
+		}
+
+		for (auto k = 0u; k < i; ++k) { 
+			l[index<MType>(n, i, i)] -= std::pow(l[index<MType>(n, i, k)], 2); 
+		} 
+
+		if (l[index<MType>(n, i, i)] == 0) { 
+            return i;
+		} 
+		else if (l[index<MType>(n, i, i)] < 0) { 
+            return i;
+		}
+
+		l[index<MType>(n, i, i)] = std::sqrt( l[index<MType>(n, i, i)] );
+	}
+    return 0;
+}
+
+template<typename T, MemType MType>
+auto cholesky_linear(size_t n, size_t nrow, const double* l, const double* rhs, double* rslt) -> double* {
+	for (auto k = 0u; k < nrow; ++k) {
+		// Forward process
+		for (auto i = 0u; i < n; ++i) {
+			rslt[k + i * nrow] = rhs[k + i * nrow];
+			for (auto j = 0u; j < i; ++j) { 
+				rslt[k + i * nrow] -= l[index<MType>(n, i, j)] * rslt[k + j * nrow]; 
+			} 
+			rslt[k + i * nrow] /= l[index<MType>(n, i, i)];
+		}
+
+		// Backward process
+		for (int32_t i = n - 1; i >= 0; --i) {
+			for (auto j = i + 1; j < static_cast<int32_t>(n); ++j) { 
+				rslt[k + i * nrow] -= l[index<MType>(n, j, i)] * rslt[k + j * nrow]; 
+			}
+			rslt[k + i * nrow] /= l[index<MType>(n, i, i)];
+		}
+	}
+	return rslt; 
+}
+
+
+}
+#endif

--- a/include/lalib/solver/internal/tdma.hpp
+++ b/include/lalib/solver/internal/tdma.hpp
@@ -5,7 +5,7 @@
 #include <concepts>
 #include <vector>
 
-namespace lalib::solver::__internal {
+namespace lalib::solver::_internal_ {
 
 template<typename T>
 requires ::std::floating_point<T>

--- a/include/lalib/solver/lapack/gtsv.hpp
+++ b/include/lalib/solver/lapack/gtsv.hpp
@@ -8,7 +8,7 @@
 
 #include <lapacke.h>
 
-namespace lalib::solver::__lapack {
+namespace lalib::solver::_lapack_ {
     
 /// @brief 
 /// @tparam T 
@@ -24,19 +24,19 @@ template<typename T>
 auto gtsv(int32_t n, int32_t nrhs, T* dl, T* d, T* du, T* b, int32_t ldb) -> int32_t = delete;
 
 template<>
-auto gtsv<float>(int32_t n, int32_t nrhs, float* dl, float* d, float* du, float* b, int32_t ldb) -> int32_t {
+inline auto gtsv<float>(int32_t n, int32_t nrhs, float* dl, float* d, float* du, float* b, int32_t ldb) -> int32_t {
     auto info = LAPACKE_sgtsv(LAPACK_ROW_MAJOR, n, nrhs, dl, d, du, b, ldb);
     return info;
 }
 
 template<>
-auto gtsv<double>(int32_t n, int32_t nrhs, double* dl, double* d, double* du, double* b, int32_t ldb) -> int32_t {
+inline auto gtsv<double>(int32_t n, int32_t nrhs, double* dl, double* d, double* du, double* b, int32_t ldb) -> int32_t {
     auto info = LAPACKE_dgtsv(LAPACK_ROW_MAJOR, n, nrhs, dl, d, du, b, ldb);
     return info;
 }
 
 template<>
-auto gtsv<std::complex<float>>(int32_t n, int32_t nrhs, std::complex<float>* dl, std::complex<float>* d, std::complex<float>* du, std::complex<float>* b, int32_t ldb) -> int32_t {
+inline auto gtsv<std::complex<float>>(int32_t n, int32_t nrhs, std::complex<float>* dl, std::complex<float>* d, std::complex<float>* du, std::complex<float>* b, int32_t ldb) -> int32_t {
     auto info = LAPACKE_cgtsv(LAPACK_ROW_MAJOR, n, nrhs, 
         reinterpret_cast<float __complex__ *>(dl), 
         reinterpret_cast<float __complex__ *>(d), 
@@ -48,7 +48,7 @@ auto gtsv<std::complex<float>>(int32_t n, int32_t nrhs, std::complex<float>* dl,
 }
 
 template<>
-auto gtsv<std::complex<double>>(int32_t n, int32_t nrhs, std::complex<double>* dl, std::complex<double>* d, std::complex<double>* du, std::complex<double>* b, int32_t ldb) -> int32_t {
+inline auto gtsv<std::complex<double>>(int32_t n, int32_t nrhs, std::complex<double>* dl, std::complex<double>* d, std::complex<double>* du, std::complex<double>* b, int32_t ldb) -> int32_t {
     auto info = LAPACKE_zgtsv(LAPACK_ROW_MAJOR, n, nrhs, 
         reinterpret_cast<double __complex__ *>(dl), 
         reinterpret_cast<double __complex__ *>(d), 

--- a/include/lalib/solver/lapack/potr.hpp
+++ b/include/lalib/solver/lapack/potr.hpp
@@ -1,0 +1,72 @@
+#pragma once
+#ifndef LALIB_SOLVER_LAPACK_POTRF_HPP
+#define LALIB_SOLVER_LAPACK_POTRF_HPP
+
+#include <cstdint>
+#include <lapacke.h>
+
+namespace lalib::solver::_lapack_ {
+
+template<typename T>
+auto potrf(int32_t n, T* l, int32_t lda) -> int32_t = delete;
+
+template<typename T>
+auto potrs(int32_t n, int32_t nrhs, const T* l, int32_t lda, T* b, int32_t ldb) -> int32_t = delete;
+
+
+// Spacialization of POTRF
+
+template<>
+inline auto potrf<float>(int32_t n, float* l, int32_t lda) -> int32_t {
+    auto info = LAPACKE_spotrf(LAPACK_ROW_MAJOR, 'L', n, l, lda);
+    return info;
+}
+
+template<>
+inline auto potrf<double>(int32_t n, double* l, int32_t lda) -> int32_t {
+    auto info = LAPACKE_dpotrf(LAPACK_ROW_MAJOR, 'L', n, l, lda);
+    return info;
+}
+
+template<>
+inline auto potrf<std::complex<float>>(int32_t n, std::complex<float>* l, int32_t lda) -> int32_t {
+    auto info = LAPACKE_cpotrf(LAPACK_ROW_MAJOR, 'L', n, reinterpret_cast<float __complex__ *>(l), lda);
+    return info;
+}
+
+template<>
+inline auto potrf<std::complex<double>>(int32_t n, std::complex<double>* l, int32_t lda) -> int32_t {
+    auto info = LAPACKE_zpotrf(LAPACK_ROW_MAJOR, 'L', n, reinterpret_cast<double __complex__ *>(l), lda);
+    return info;
+}
+
+
+// Spacialization of POTRS
+
+template<>
+inline auto potrs<float>(int32_t n, int32_t nrhs, const float* l, int32_t lda, float* b, int32_t ldb) -> int32_t {
+    auto info = LAPACKE_spotrs(LAPACK_ROW_MAJOR, 'L', n, nrhs, l, lda, b, ldb);
+    return info;
+}
+
+template<>
+inline auto potrs<double>(int32_t n, int32_t nrhs, const double* l, int32_t lda, double* b, int32_t ldb) -> int32_t {
+    auto info = LAPACKE_dpotrs(LAPACK_ROW_MAJOR, 'L', n, nrhs, l, lda, b, ldb);
+    return info;
+}
+
+template<>
+inline auto potrs<std::complex<float>>(int32_t n, int32_t nrhs, const std::complex<float>* l, int32_t lda, std::complex<float>* b, int32_t ldb) -> int32_t {
+    auto info = LAPACKE_cpotrs(LAPACK_ROW_MAJOR, 'L', n, nrhs, reinterpret_cast<const float __complex__ *>(l), lda, reinterpret_cast<float __complex__ *>(b), ldb);
+    return info;
+}
+
+template<>
+inline auto potrs<std::complex<double>>(int32_t n, int32_t nrhs, const std::complex<double>* l, int32_t lda, std::complex<double>* b, int32_t ldb) -> int32_t {
+    auto info = LAPACKE_zpotrs(LAPACK_ROW_MAJOR, 'L', n, nrhs, reinterpret_cast<const double __complex__ *>(l), lda, reinterpret_cast<double __complex__ *>(b), ldb);
+    return info;
+}
+
+}
+
+#endif

--- a/include/lalib/solver/tri_diag.hpp
+++ b/include/lalib/solver/tri_diag.hpp
@@ -55,9 +55,9 @@ inline auto TriDiag<M>::solve_linear(const V &b, V &rslt) noexcept -> V &
 
     #if defined(LALIB_LAPACK_BACKEND)
     rslt = b;
-    __lapack::gtsv(n, 1, this->_mat.data_dl(), this->_mat.data_d(), this->_mat.data_du(), rslt.data(), 1);
+    _lapack_::gtsv(n, 1, this->_mat.data_dl(), this->_mat.data_d(), this->_mat.data_du(), rslt.data(), 1);
     #else
-    __internal::tdma(n, 1, this->_mat.data_dl(), this->_mat.data_d(), this->_mat.data_du(), b.data(), rslt.data());
+    _internal_::tdma(n, 1, this->_mat.data_dl(), this->_mat.data_d(), this->_mat.data_du(), b.data(), rslt.data());
     #endif
 
     return rslt;
@@ -75,9 +75,9 @@ inline auto lalib::solver::TriDiag<M>::solve_linear(const M1 & b, M1 & rslt) noe
 
     #if defined(LALIB_LAPACK_BACKEND)
     rslt = b;
-    __lapack::gtsv(n, nrow, this->_mat.data_dl(), this->_mat.data_d(), this->_mat.data_du(), rslt.data(), rslt.shape().second);
+    _lapack_::gtsv(n, nrow, this->_mat.data_dl(), this->_mat.data_d(), this->_mat.data_du(), rslt.data(), rslt.shape().second);
     #else
-    __internal::tdma(n, nrow, this->_mat.data_dl(), this->_mat.data_d(), this->_mat.data_du(), b.data(), rslt.data());
+    _internal_::tdma(n, nrow, this->_mat.data_dl(), this->_mat.data_d(), this->_mat.data_du(), b.data(), rslt.data());
     #endif
 
     return rslt;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -49,7 +49,7 @@ target_link_libraries(lalib_tri_diag_test PRIVATE
 )
 gtest_discover_tests(lalib_tri_diag_test)
 
-add_executable(lalib_cholesky_decomposition_test solver/cholesky_decomposition.cc)
+add_executable(lalib_cholesky_decomposition_test solver/cholesky_factorization.cc)
 target_link_libraries(lalib_cholesky_decomposition_test PRIVATE 
     $<$<BOOL:${LAPACK_FOUND}>:LAPACK::LAPACK> 
     $<$<BOOL:${LAPACK_FOUND}>:-llapacke>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -49,6 +49,15 @@ target_link_libraries(lalib_tri_diag_test PRIVATE
 )
 gtest_discover_tests(lalib_tri_diag_test)
 
+add_executable(lalib_cholesky_decomposition_test solver/cholesky_decomposition.cc)
+target_link_libraries(lalib_cholesky_decomposition_test PRIVATE 
+    $<$<BOOL:${LAPACK_FOUND}>:LAPACK::LAPACK> 
+    $<$<BOOL:${LAPACK_FOUND}>:-llapacke>
+    ${BLAS_LIBRARIES} ${OpenMP_CXX_LIBRARIES} 
+    GTest::GTest GTest::Main
+)
+gtest_discover_tests(lalib_cholesky_decomposition_test)
+
 
 ## Errors
 add_executable(lalib_error_test err/error.cc)

--- a/test/ops/mat_mat_ops.cc
+++ b/test/ops/mat_mat_ops.cc
@@ -2,6 +2,36 @@
 #include "lalib/ops/mat_mat_ops.hpp"
 #include <iostream>
 
+TEST(MatMatOpsTests, SizedMatSizedMatAddTest) {
+    auto m1 = lalib::SizedMat<double, 2, 3>({
+        1.0, 3.0, 5.0,
+        2.0, 4.0, 6.0
+    });
+    auto m2 = m1 + m1;
+
+    ASSERT_DOUBLE_EQ(2 * m1(0, 0), m2(0, 0));
+    ASSERT_DOUBLE_EQ(2 * m1(0, 1), m2(0, 1));
+    ASSERT_DOUBLE_EQ(2 * m1(0, 2), m2(0, 2));
+    ASSERT_DOUBLE_EQ(2 * m1(1, 0), m2(1, 0));
+    ASSERT_DOUBLE_EQ(2 * m1(1, 1), m2(1, 1));
+    ASSERT_DOUBLE_EQ(2 * m1(1, 2), m2(1, 2));
+}
+
+TEST(MatMatOpsTests, SizedMatSizedMatSubTest) {
+    auto m1 = lalib::SizedMat<double, 2, 3>({
+        1.0, 3.0, 5.0,
+        2.0, 4.0, 6.0
+    });
+    auto m2 = m1 - m1;
+
+    ASSERT_DOUBLE_EQ(0.0, m2(0, 0));
+    ASSERT_DOUBLE_EQ(0.0, m2(0, 1));
+    ASSERT_DOUBLE_EQ(0.0, m2(0, 2));
+    ASSERT_DOUBLE_EQ(0.0, m2(1, 0));
+    ASSERT_DOUBLE_EQ(0.0, m2(1, 1));
+    ASSERT_DOUBLE_EQ(0.0, m2(1, 2));
+}
+
 TEST(MatMatOpsTests, SizedMatSizedMatMulTest) {
     auto m1 = lalib::SizedMat<double, 2, 3>({
         1.0, 3.0, 5.0,

--- a/test/solver/cholesky_factorization.cc
+++ b/test/solver/cholesky_factorization.cc
@@ -71,12 +71,12 @@ TEST(CholeskyDecompositionTests, LinearSolverTest) {
 		6.0, 5.0, 14.0
 	}, 3, 3);
 
-	auto b = lalib::DynVecD({ 2.0, 5.0, 1.0 });
-    auto rslt = lalib::DynVecD::filled(3, 0.0);
+	const auto b = lalib::DynVecD({ 2.0, 5.0, 1.0 });
+    auto rslt = b;
 
 	{
 		auto cholesky = lalib::solver::DynTriCholeskyFactorization(std::move(mat));
-		cholesky.solve_linear(b, rslt);
+		cholesky.solve_linear_mut(rslt);
 		
 		EXPECT_DOUBLE_EQ(1.25, rslt[0]);
 		EXPECT_DOUBLE_EQ(1.5, rslt[1]);
@@ -84,7 +84,7 @@ TEST(CholeskyDecompositionTests, LinearSolverTest) {
 	}
 	{
 		auto cholesky = lalib::solver::DynCholeskyFactorization(std::move(mat_sq));
-		cholesky.solve_linear(b, rslt);
+		auto rslt = cholesky.solve_linear(b);
 		
 		EXPECT_DOUBLE_EQ(1.25, rslt[0]);
 		EXPECT_DOUBLE_EQ(1.5, rslt[1]);
@@ -104,16 +104,16 @@ TEST(CholeskyDecompositionTests, MultiLinearSolverTest) {
 		6.0, 5.0, 14.0
 	}, 3, 3);
 
-	auto b = lalib::DynMatD({ 
+	const auto b = lalib::DynMatD({ 
         2.0, 0.0,
         5.0, 2.0, 
         1.0, -1.0
     }, 3, 2);
-    auto rslt = lalib::DynMatD::filled(0.0, 3, 2);
 
 	{
+		auto rslt = b;
 		auto cholesky = lalib::solver::DynTriCholeskyFactorization(std::move(mat));
-		cholesky.solve_linear(b, rslt);
+		cholesky.solve_linear_mut(rslt);
 		
 		EXPECT_DOUBLE_EQ(1.25, rslt(0, 0));
 		EXPECT_DOUBLE_EQ(1.5, rslt(1, 0));
@@ -125,7 +125,7 @@ TEST(CholeskyDecompositionTests, MultiLinearSolverTest) {
 	}
 	{
 		auto cholesky = lalib::solver::DynCholeskyFactorization(std::move(mat_sq));
-		cholesky.solve_linear(b, rslt);
+		auto rslt = cholesky.solve_linear(b);
 		
 		EXPECT_DOUBLE_EQ(1.25, rslt(0, 0));
 		EXPECT_DOUBLE_EQ(1.5, rslt(1, 0));

--- a/test/solver/cholesky_factorization.cc
+++ b/test/solver/cholesky_factorization.cc
@@ -1,0 +1,84 @@
+#include <gtest/gtest.h>
+#include "lalib/solver/cholesky_factorization.hpp"
+#include "lalib/mat.hpp"
+#include "lalib/vec.hpp"
+
+#if defined LALIB_LAPACK_BACKEND
+#include "lalib/solver/lapack/potr.hpp"
+TEST(CholeskyDecompositionTests, LapackCholeskyDecompositionTest) {
+    auto mat = lalib::DynMat<double>(std::vector{
+		4.0, 2.0, 6.0,
+		2.0, 5.0, 5.0,
+		6.0, 5.0, 14.0
+	}, 3, 3);
+    auto rslt = lalib::solver::_lapack_::potrf(mat.shape().first, mat.data(), mat.shape().second);
+
+    ASSERT_EQ(0, rslt);
+	EXPECT_DOUBLE_EQ(2.0, mat(0, 0));
+	EXPECT_DOUBLE_EQ(1.0, mat(1, 0));
+	EXPECT_DOUBLE_EQ(2.0, mat(1, 1));
+	EXPECT_DOUBLE_EQ(3.0, mat(2, 0));
+	EXPECT_DOUBLE_EQ(1.0, mat(2, 1));
+	EXPECT_DOUBLE_EQ(2.0, mat(2, 2));
+}
+#endif
+
+TEST(CholeskyDecompositionTests, CholeskyDecompositionTest) {
+    auto mat = lalib::DynHermiteMat<double>(3, std::vector{
+		4.0, 
+		2.0, 5.0, 
+		6.0, 5.0, 14.0
+	});
+
+	auto cholesky = lalib::solver::DynTriCholeskyFactorization<double>(std::move(mat));
+    auto l = cholesky.lower_matrix();
+
+	EXPECT_DOUBLE_EQ(2.0, l(0, 0));
+	EXPECT_DOUBLE_EQ(1.0, l(1, 0));
+	EXPECT_DOUBLE_EQ(2.0, l(1, 1));
+	EXPECT_DOUBLE_EQ(3.0, l(2, 0));
+	EXPECT_DOUBLE_EQ(1.0, l(2, 1));
+	EXPECT_DOUBLE_EQ(2.0, l(2, 2));
+}
+
+TEST(CholeskyDecompositionTests, LinearSolverTest) {
+    auto mat = lalib::DynHermiteMat<double>(3, std::vector{
+		4.0, 
+		2.0, 5.0, 
+		6.0, 5.0, 14.0
+	});
+	auto b = lalib::DynVecD({ 2.0, 5.0, 1.0 });
+    auto rslt = lalib::DynVecD::filled(3, 0.0);
+
+	auto cholesky = lalib::solver::DynTriCholeskyFactorization(std::move(mat));
+    cholesky.solve_linear(b, rslt);
+	
+	EXPECT_DOUBLE_EQ(1.25, rslt[0]);
+	EXPECT_DOUBLE_EQ(1.5, rslt[1]);
+	EXPECT_DOUBLE_EQ(-1.0, rslt[2]);
+}
+
+TEST(CholeskyDecompositionTests, MultiLinearSolverTest) {
+    auto mat = lalib::DynHermiteMat<double>(3, std::vector{
+		4.0, 
+		2.0, 5.0, 
+		6.0, 5.0, 14.0
+	});
+	auto b = lalib::DynMatD({ 
+        2.0, 0.0,
+        5.0, 2.0, 
+        1.0, -1.0
+    }, 3, 2);
+    auto rslt = lalib::DynMatD::filled(0.0, 3, 2);
+
+	auto cholesky = lalib::solver::DynTriCholeskyFactorization(std::move(mat));
+    cholesky.solve_linear(b, rslt);
+	
+	EXPECT_DOUBLE_EQ(1.25, rslt(0, 0));
+	EXPECT_DOUBLE_EQ(1.5, rslt(1, 0));
+	EXPECT_DOUBLE_EQ(-1.0, rslt(2, 0));
+
+	EXPECT_DOUBLE_EQ(0.375, rslt(0, 1));
+	EXPECT_DOUBLE_EQ(0.75, rslt(1, 1));
+	EXPECT_DOUBLE_EQ(-0.5, rslt(2, 1));
+}

--- a/test/solver/cholesky_factorization.cc
+++ b/test/solver/cholesky_factorization.cc
@@ -29,16 +29,34 @@ TEST(CholeskyDecompositionTests, CholeskyDecompositionTest) {
 		2.0, 5.0, 
 		6.0, 5.0, 14.0
 	});
+    auto mat_sq = lalib::DynMat<double>(std::vector{
+		4.0, 2.0, 6.0,
+		2.0, 5.0, 5.0,
+		6.0, 5.0, 14.0
+	}, 3, 3);
 
-	auto cholesky = lalib::solver::DynTriCholeskyFactorization<double>(std::move(mat));
-    auto l = cholesky.lower_matrix();
+	{
+		auto cholesky = lalib::solver::DynTriCholeskyFactorization<double>(std::move(mat));
+		auto l = cholesky.lower_mat();
 
-	EXPECT_DOUBLE_EQ(2.0, l(0, 0));
-	EXPECT_DOUBLE_EQ(1.0, l(1, 0));
-	EXPECT_DOUBLE_EQ(2.0, l(1, 1));
-	EXPECT_DOUBLE_EQ(3.0, l(2, 0));
-	EXPECT_DOUBLE_EQ(1.0, l(2, 1));
-	EXPECT_DOUBLE_EQ(2.0, l(2, 2));
+		EXPECT_DOUBLE_EQ(2.0, l(0, 0));
+		EXPECT_DOUBLE_EQ(1.0, l(1, 0));
+		EXPECT_DOUBLE_EQ(2.0, l(1, 1));
+		EXPECT_DOUBLE_EQ(3.0, l(2, 0));
+		EXPECT_DOUBLE_EQ(1.0, l(2, 1));
+		EXPECT_DOUBLE_EQ(2.0, l(2, 2));
+	}
+	{
+		auto cholesky = lalib::solver::DynCholeskyFactorization<double>(std::move(mat_sq));
+		auto l = cholesky.factor_mat();
+
+		EXPECT_DOUBLE_EQ(2.0, l(0, 0));
+		EXPECT_DOUBLE_EQ(1.0, l(1, 0));
+		EXPECT_DOUBLE_EQ(2.0, l(1, 1));
+		EXPECT_DOUBLE_EQ(3.0, l(2, 0));
+		EXPECT_DOUBLE_EQ(1.0, l(2, 1));
+		EXPECT_DOUBLE_EQ(2.0, l(2, 2));
+	}
 }
 
 TEST(CholeskyDecompositionTests, LinearSolverTest) {
@@ -47,15 +65,31 @@ TEST(CholeskyDecompositionTests, LinearSolverTest) {
 		2.0, 5.0, 
 		6.0, 5.0, 14.0
 	});
+    auto mat_sq = lalib::DynMat<double>(std::vector{
+		4.0, 2.0, 6.0,
+		2.0, 5.0, 5.0,
+		6.0, 5.0, 14.0
+	}, 3, 3);
+
 	auto b = lalib::DynVecD({ 2.0, 5.0, 1.0 });
     auto rslt = lalib::DynVecD::filled(3, 0.0);
 
-	auto cholesky = lalib::solver::DynTriCholeskyFactorization(std::move(mat));
-    cholesky.solve_linear(b, rslt);
-	
-	EXPECT_DOUBLE_EQ(1.25, rslt[0]);
-	EXPECT_DOUBLE_EQ(1.5, rslt[1]);
-	EXPECT_DOUBLE_EQ(-1.0, rslt[2]);
+	{
+		auto cholesky = lalib::solver::DynTriCholeskyFactorization(std::move(mat));
+		cholesky.solve_linear(b, rslt);
+		
+		EXPECT_DOUBLE_EQ(1.25, rslt[0]);
+		EXPECT_DOUBLE_EQ(1.5, rslt[1]);
+		EXPECT_DOUBLE_EQ(-1.0, rslt[2]);
+	}
+	{
+		auto cholesky = lalib::solver::DynCholeskyFactorization(std::move(mat_sq));
+		cholesky.solve_linear(b, rslt);
+		
+		EXPECT_DOUBLE_EQ(1.25, rslt[0]);
+		EXPECT_DOUBLE_EQ(1.5, rslt[1]);
+		EXPECT_DOUBLE_EQ(-1.0, rslt[2]);
+	}
 }
 
 TEST(CholeskyDecompositionTests, MultiLinearSolverTest) {
@@ -64,6 +98,12 @@ TEST(CholeskyDecompositionTests, MultiLinearSolverTest) {
 		2.0, 5.0, 
 		6.0, 5.0, 14.0
 	});
+    auto mat_sq = lalib::DynMat<double>(std::vector{
+		4.0, 2.0, 6.0,
+		2.0, 5.0, 5.0,
+		6.0, 5.0, 14.0
+	}, 3, 3);
+
 	auto b = lalib::DynMatD({ 
         2.0, 0.0,
         5.0, 2.0, 
@@ -71,14 +111,28 @@ TEST(CholeskyDecompositionTests, MultiLinearSolverTest) {
     }, 3, 2);
     auto rslt = lalib::DynMatD::filled(0.0, 3, 2);
 
-	auto cholesky = lalib::solver::DynTriCholeskyFactorization(std::move(mat));
-    cholesky.solve_linear(b, rslt);
-	
-	EXPECT_DOUBLE_EQ(1.25, rslt(0, 0));
-	EXPECT_DOUBLE_EQ(1.5, rslt(1, 0));
-	EXPECT_DOUBLE_EQ(-1.0, rslt(2, 0));
+	{
+		auto cholesky = lalib::solver::DynTriCholeskyFactorization(std::move(mat));
+		cholesky.solve_linear(b, rslt);
+		
+		EXPECT_DOUBLE_EQ(1.25, rslt(0, 0));
+		EXPECT_DOUBLE_EQ(1.5, rslt(1, 0));
+		EXPECT_DOUBLE_EQ(-1.0, rslt(2, 0));
 
-	EXPECT_DOUBLE_EQ(0.375, rslt(0, 1));
-	EXPECT_DOUBLE_EQ(0.75, rslt(1, 1));
-	EXPECT_DOUBLE_EQ(-0.5, rslt(2, 1));
+		EXPECT_DOUBLE_EQ(0.375, rslt(0, 1));
+		EXPECT_DOUBLE_EQ(0.75, rslt(1, 1));
+		EXPECT_DOUBLE_EQ(-0.5, rslt(2, 1));
+	}
+	{
+		auto cholesky = lalib::solver::DynCholeskyFactorization(std::move(mat_sq));
+		cholesky.solve_linear(b, rslt);
+		
+		EXPECT_DOUBLE_EQ(1.25, rslt(0, 0));
+		EXPECT_DOUBLE_EQ(1.5, rslt(1, 0));
+		EXPECT_DOUBLE_EQ(-1.0, rslt(2, 0));
+
+		EXPECT_DOUBLE_EQ(0.375, rslt(0, 1));
+		EXPECT_DOUBLE_EQ(0.75, rslt(1, 1));
+		EXPECT_DOUBLE_EQ(-0.5, rslt(2, 1));
+	}
 }


### PR DESCRIPTION
# Overview
This pull request introduces a feature of Cholesky factorization.
According to this update, following new matrix types are also added.
* `SizedHermiteMat`: Hermitian matrix whose size is fixed at the compile time.
* `SizedLowerTriMat`: Lower triangular matrix whose size is fixed at the compile time.
* `DynHermiteMat`: Hermitian matrix that the memory will be allocated in an execution time.
* `DynLowerTriMat`: Lower triangular matrix that its memory will be allocated in an execution time.