### PR TITLE
[Destructive API Change] Vectors and Matrices is constructible with initializer-list

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(lalib VERSION 0.5.2 LANGUAGES C CXX)
+project(lalib VERSION 0.6.0 LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED True)

--- a/include/lalib/mat/dyn_mat.hpp
+++ b/include/lalib/mat/dyn_mat.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <initializer_list>
 #ifndef LALIB_MAT_DYN_MAT_HPP
 #define LALIB_MAT_DYN_MAT_HPP
 
@@ -15,7 +16,12 @@ public:
     // ==== Initializations ==== //
 
     /// @brief Create a sized matrix with given array with copy.
-    constexpr DynMat(const std::vector<T>& arr, size_t n, size_t m) noexcept: 
+    constexpr DynMat(size_t n, size_t m, const std::vector<T>& arr) noexcept: 
+        _elems(arr), _shape(std::make_pair(n, m)) 
+    {}
+
+    /// @brief Create a sized matrix with given array with copy.
+    [[deprecated]] constexpr DynMat(const std::vector<T>& arr, size_t n, size_t m) noexcept: 
         _elems(arr), _shape(std::make_pair(n, m)) 
     {}
 
@@ -89,7 +95,7 @@ private:
 template <typename T>
 inline constexpr auto DynMat<T>::uninit(size_t n, size_t m) noexcept -> DynMat<T>
 {
-    return DynMat<T>(std::vector<T>(n * m), n, m);
+    return DynMat<T>(n, m, std::vector<T>(n * m));
 }
 
 template <typename T>

--- a/include/lalib/mat/dyn_mat.hpp
+++ b/include/lalib/mat/dyn_mat.hpp
@@ -19,6 +19,11 @@ public:
         _elems(arr), _shape(std::make_pair(n, m)) 
     {}
 
+    /// @brief Create a sized matrix with given array with copy.
+    constexpr DynMat(size_t n, size_t m, std::initializer_list<T> init) noexcept: 
+        _elems(init), _shape(std::make_pair(n, m)) 
+    {}
+
     /// @brief A copy constructor
     constexpr DynMat(const DynMat<T>& vec) noexcept = default;
 

--- a/include/lalib/mat/sized_mat.hpp
+++ b/include/lalib/mat/sized_mat.hpp
@@ -1,8 +1,10 @@
 #pragma once
+#include <initializer_list>
 #ifndef LALIB_MAT_SIZED_MAT_HPP
 #define LALIB_MAT_SIZED_MAT_HPP
 
 #include <array>
+#include <vector>
 #include <utility>
 #include "lalib/ops/ops_traits.hpp"
 #include "lalib/type_traits.hpp"
@@ -23,6 +25,12 @@ public:
     /// @brief Create a sized matrix with given array with copy.
     constexpr SizedMat(const std::array<T, M * N>& arr) noexcept: 
         _elems(arr) {}
+
+    /// @brief Create a sized matrix with given vector with copy.
+    SizedMat(const std::vector<T>& vec);
+
+    /// @brief Create a sized matrix with given initializer list.
+    SizedMat(std::initializer_list<T> init);
 
     /// @brief A copy constructor
     constexpr SizedMat(const SizedMat<T, N, M>& vec) noexcept = default;
@@ -84,6 +92,31 @@ private:
 };
 
 
+template<typename T, size_t N, size_t M>
+inline SizedMat<T, N, M>::SizedMat(std::initializer_list<T> init):
+    _elems()
+{
+    if (init.size() != N * M) {
+        throw std::runtime_error(
+            "mismatch size of the given vector. " 
+            "expected: " + std::to_string(N * M) + " vec.size(): " + std::to_string(init.size())
+        );
+    }
+    std::copy(init.begin(), init.end(), this->_elems.begin());
+}
+
+template<typename T, size_t N, size_t M>
+inline SizedMat<T, N, M>::SizedMat(const std::vector<T>& vec):
+    _elems()
+{
+    if (vec.size() != N * M) {
+        throw std::runtime_error(
+            "mismatch size of the given vector. " 
+            "expected: " + std::to_string(N * M) + " vec.size(): " + std::to_string(vec.size())
+        );
+    }
+    std::copy(vec.begin(), vec.end(), this->_elems.begin());
+}
 
 template <typename T, size_t N, size_t M>
 inline constexpr auto SizedMat<T, N, M>::uninit() noexcept -> SizedMat<T, N, M>

--- a/include/lalib/vec/dyn_vec.hpp
+++ b/include/lalib/vec/dyn_vec.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <initializer_list>
 #ifndef LALIB_VEC_DYN_VEC_HPP
 #define LALIB_VEC_DYN_VEC_HPP
 

--- a/include/lalib/vec/dyn_vec.hpp
+++ b/include/lalib/vec/dyn_vec.hpp
@@ -24,6 +24,10 @@ public:
     constexpr DynVec(const std::vector<T>& vec) noexcept: 
         _elems(vec) {}
 
+    /// @brief Create a sized vector with given initializer list.
+    constexpr DynVec(std::initializer_list<T> init) noexcept: 
+        _elems(init) {}
+
     /// @brief Create a sized vector with given array with move.
     constexpr DynVec(std::vector<T>&& vec) noexcept: 
         _elems( std::move(vec) ) {}

--- a/include/lalib/vec/sized_vec.hpp
+++ b/include/lalib/vec/sized_vec.hpp
@@ -1,8 +1,11 @@
 #pragma once
+#include <stdexcept>
 #ifndef LALIB_VEC_SIZED_VEC_HPP
 #define LALIB_VEC_SIZED_VEC_HPP
 
 #include <array>
+#include <vector>
+#include <initializer_list>
 #include "lalib/ops/vec_ops_core.hpp"
 
 namespace lalib {
@@ -21,6 +24,12 @@ public:
     /// @brief Create a sized vector with given array with copy.
     constexpr SizedVec(const std::array<T, N>& arr) noexcept: 
         _elems(arr) {}
+
+    /// @brief Create a sized vector with given vector with copy.
+    SizedVec(const std::vector<T>& vec);
+
+    /// @brief Create a sized vector with given initializer list.
+    SizedVec(std::initializer_list<T> init);
 
     /// @brief A copy constructor
     constexpr SizedVec(const SizedVec& vec) noexcept = default;
@@ -83,6 +92,32 @@ constexpr auto generate_std_array_filled_with(T value) -> std::array<T, N> {
         arr.fill(value);
         return arr;
     }();
+}
+
+template<typename T, size_t N>
+inline SizedVec<T, N>::SizedVec(const std::vector<T>& vec):
+    _elems() 
+{
+    if (vec.size() != N) {
+        throw std::runtime_error(
+            "mismatch size of the given vector. " 
+            "expected: " + std::to_string(N) + " vec.size(): " + std::to_string(vec.size())
+        );
+    }
+    std::copy(vec.begin(), vec.end(), this->_elems.begin());
+}
+
+template<typename T, size_t N>
+inline SizedVec<T, N>::SizedVec(std::initializer_list<T> init):
+    _elems()
+{
+    if (init.size() != N) {
+        throw std::runtime_error(
+            "mismatch size of the given initializer list. " 
+            "expected: " + std::to_string(N) + " vec.size(): " + std::to_string(init.size())
+        );
+    }
+    std::copy(init.begin(), init.end(), this->_elems.begin());
 }
 
 template <typename T, size_t N>

--- a/test/mat/dyn_mat.cc
+++ b/test/mat/dyn_mat.cc
@@ -2,10 +2,10 @@
 #include <gtest/gtest.h>
 
 TEST(DynMatTests, CopyConstTest) {
-    auto mat = lalib::DynMat<double>({
+    auto mat = lalib::DynMat<double>(2, 4, {
         1.0, 2.0, 3.0, 4.0,
         2.0, 1.0, 5.0, 3.0
-    }, 2, 4);
+    });
 
     auto mat_copy = mat;
 
@@ -20,10 +20,10 @@ TEST(DynMatTests, CopyConstTest) {
 }
 
 TEST(DynMatTests, CopyAssignTest) {
-    auto mat = lalib::DynMat<double>({
+    auto mat = lalib::DynMat<double>(2, 4, {
         1.0, 2.0, 3.0, 4.0,
         2.0, 1.0, 5.0, 3.0
-    }, 2, 4);
+    });
     auto mat_copy = lalib::DynMat<double>::uninit(2, 4);
 
     mat_copy = mat;
@@ -39,10 +39,10 @@ TEST(DynMatTests, CopyAssignTest) {
 }
 
 TEST(DynMatTests, ShapeTest) {
-    auto mat = lalib::DynMat<double>({
+    auto mat = lalib::DynMat<double>(2, 4, {
         1.0, 2.0, 3.0, 4.0,
         2.0, 1.0, 5.0, 3.0
-    }, 2, 4);
+    });
 
     ASSERT_EQ(2, mat.shape().first);
     ASSERT_EQ(4, mat.shape().second);

--- a/test/mat/sized_mat.cc
+++ b/test/mat/sized_mat.cc
@@ -1,11 +1,46 @@
 #include "lalib/mat/sized_mat.hpp"
 #include <gtest/gtest.h>
+#include <stdexcept>
+
+TEST(SizedMatTests, VecConstTest) {
+    using MatD24 = lalib::SizedMat<double, 2, 4>;
+    using MatD23 = lalib::SizedMat<double, 2, 3>;
+    EXPECT_NO_THROW({
+        MatD24(std::vector{
+            1.0, 2.0, 3.0, 4.0,
+            2.0, 1.0, 5.0, 3.0
+        });
+    });
+    EXPECT_THROW({
+        MatD23(std::vector{
+            1.0, 2.0, 3.0, 4.0,
+            2.0, 1.0, 5.0, 3.0
+        });
+    }, std::runtime_error);
+}
+
+TEST(SizedMatTests, InitListConstTest) {
+    using MatD24 = lalib::SizedMat<double, 2, 4>;
+    using MatD23 = lalib::SizedMat<double, 2, 3>;
+    EXPECT_NO_THROW({
+        MatD24 ({
+            1.0, 2.0, 3.0, 4.0,
+            2.0, 1.0, 5.0, 3.0
+        });
+    });
+    EXPECT_THROW({
+        MatD23({
+            1.0, 2.0, 3.0, 4.0,
+            2.0, 1.0, 5.0, 3.0
+        });
+    }, std::runtime_error);
+}
 
 TEST(SizedMatTests, CopyConstTest) {
-    auto mat = lalib::SizedMat<double, 2, 4>({
+    auto mat = lalib::SizedMat<double, 2, 4> {
         1.0, 2.0, 3.0, 4.0,
         2.0, 1.0, 5.0, 3.0
-    });
+    };
 
     auto mat_copy = mat;
 
@@ -20,10 +55,10 @@ TEST(SizedMatTests, CopyConstTest) {
 }
 
 TEST(SizedMatTests, CopyAssignTest) {
-    auto mat = lalib::SizedMat<double, 2, 4>({
+    auto mat = lalib::SizedMat<double, 2, 4> {
         1.0, 2.0, 3.0, 4.0,
         2.0, 1.0, 5.0, 3.0
-    });
+    };
     auto mat_copy = lalib::SizedMat<double, 2, 4>::uninit();
 
     mat_copy = mat;
@@ -39,10 +74,10 @@ TEST(SizedMatTests, CopyAssignTest) {
 }
 
 TEST(SizedMatTests, ShapeTest) {
-    auto mat = lalib::SizedMat<double, 2, 4>({
+    auto mat = lalib::SizedMat<double, 2, 4> {
         1.0, 2.0, 3.0, 4.0,
         2.0, 1.0, 5.0, 3.0
-    });
+    };
 
     ASSERT_EQ(2, mat.shape().first);
     ASSERT_EQ(4, mat.shape().second);

--- a/test/ops/mat_mat_ops.cc
+++ b/test/ops/mat_mat_ops.cc
@@ -62,15 +62,15 @@ TEST(MatMatOpsTests, SizedMatSizedMatMulTest) {
 
 
 TEST(MatMatOpsTests, DynMatDynMatMulTest) {
-    auto m1 = lalib::DynMat<double>({
+    auto m1 = lalib::DynMat<double>(2, 3, {
         1.0, 3.0, 5.0,
         2.0, 4.0, 6.0
-    }, 2, 3);
-    auto m2 = lalib::DynMat<double>({ 
+    });
+    auto m2 = lalib::DynMat<double>(3, 2, { 
         1.0, 2.0,
         2.0, 3.0,
         3.0, 4.0
-    }, 3, 2);
+    });
     auto m3 = lalib::DynMat<double>::filled(1.0, 2, 2);
     auto alpha = 2.0;
     auto beta = 3.0;

--- a/test/ops/mat_vec_ops.cc
+++ b/test/ops/mat_vec_ops.cc
@@ -38,10 +38,10 @@ TEST(MatVecOpsTests, SizedMatSizedVecMulTest) {
 TEST(MatVecOpsTests, SizedMatDynVecMulTest) {
     auto alpha = 2.0;
     auto beta = 3.0;
-    auto m = lalib::DynMat<double>({
+    auto m = lalib::DynMat<double>(2, 4, {
         1.0, 2.0, 3.0, 4.0,
         2.0, 4.0, 1.0, 3.0
-    }, 2, 4);
+    });
     auto v = lalib::SizedVec<double, 4>({2.0, 3.0, 4.0, 1.0});
     auto dynv = lalib::DynVec<double>({2.0, 3.0, 4.0, 1.0});
 

--- a/test/solver/cholesky_factorization.cc
+++ b/test/solver/cholesky_factorization.cc
@@ -6,11 +6,11 @@
 #if defined LALIB_LAPACK_BACKEND
 #include "lalib/solver/lapack/potr.hpp"
 TEST(CholeskyDecompositionTests, LapackCholeskyDecompositionTest) {
-    auto mat = lalib::DynMat<double>(std::vector{
+    auto mat = lalib::DynMat<double>(3, 3, {
 		4.0, 2.0, 6.0,
 		2.0, 5.0, 5.0,
 		6.0, 5.0, 14.0
-	}, 3, 3);
+	});
     auto rslt = lalib::solver::_lapack_::potrf(mat.shape().first, mat.data(), mat.shape().second);
 
     ASSERT_EQ(0, rslt);
@@ -29,11 +29,11 @@ TEST(CholeskyDecompositionTests, CholeskyDecompositionTest) {
 		2.0, 5.0, 
 		6.0, 5.0, 14.0
 	});
-    auto mat_sq = lalib::DynMat<double>(std::vector{
+    auto mat_sq = lalib::DynMat<double>(3, 3, {
 		4.0, 2.0, 6.0,
 		2.0, 5.0, 5.0,
 		6.0, 5.0, 14.0
-	}, 3, 3);
+	});
 
 	{
 		auto cholesky = lalib::solver::DynTriCholeskyFactorization<double>(std::move(mat));
@@ -65,11 +65,11 @@ TEST(CholeskyDecompositionTests, LinearSolverTest) {
 		2.0, 5.0, 
 		6.0, 5.0, 14.0
 	});
-    auto mat_sq = lalib::DynMat<double>(std::vector{
+    auto mat_sq = lalib::DynMat<double>(3, 3, {
 		4.0, 2.0, 6.0,
 		2.0, 5.0, 5.0,
 		6.0, 5.0, 14.0
-	}, 3, 3);
+	});
 
 	const auto b = lalib::DynVecD({ 2.0, 5.0, 1.0 });
     auto rslt = b;
@@ -98,17 +98,17 @@ TEST(CholeskyDecompositionTests, MultiLinearSolverTest) {
 		2.0, 5.0, 
 		6.0, 5.0, 14.0
 	});
-    auto mat_sq = lalib::DynMat<double>(std::vector{
+    auto mat_sq = lalib::DynMat<double>(3, 3, {
 		4.0, 2.0, 6.0,
 		2.0, 5.0, 5.0,
 		6.0, 5.0, 14.0
-	}, 3, 3);
+	});
 
-	const auto b = lalib::DynMatD({ 
+	const auto b = lalib::DynMatD(3, 2, { 
         2.0, 0.0,
         5.0, 2.0, 
         1.0, -1.0
-    }, 3, 2);
+    });
 
 	{
 		auto rslt = b;
@@ -138,11 +138,11 @@ TEST(CholeskyDecompositionTests, MultiLinearSolverTest) {
 }
 
 TEST(ModCholeskyDecompositionTests, DecompositionTest) {
-    auto mat_sq = lalib::DynMat<double>(std::vector{
+    auto mat_sq = lalib::DynMat<double>(3, 3, std::vector{
 		4.0, 2.0, 6.0,
 		2.0, 5.0, 5.0,
 		6.0, 5.0, 14.0
-	}, 3, 3);
+	});
 
 	{
 		auto cholesky = lalib::solver::DynModCholeskyFactorization<double>(std::move(mat_sq));
@@ -158,11 +158,11 @@ TEST(ModCholeskyDecompositionTests, DecompositionTest) {
 }
 
 TEST(ModCholeskyDecompositionTests, LinearSolverTest) {
-    auto mat_sq = lalib::DynMat<double>(std::vector{
+    auto mat_sq = lalib::DynMat<double>(3, 3, {
 		4.0, 2.0, 6.0,
 		2.0, 5.0, 5.0,
 		6.0, 5.0, 14.0
-	}, 3, 3);
+	});
 
 	const auto b = lalib::DynVecD({ 2.0, 5.0, 1.0 });
 	{
@@ -176,17 +176,17 @@ TEST(ModCholeskyDecompositionTests, LinearSolverTest) {
 }
 
 TEST(ModCholeskyDecompositionTests, MultiLinearSolverTest) {
-    auto mat_sq = lalib::DynMat<double>(std::vector{
+    auto mat_sq = lalib::DynMat<double>(3, 3, {
 		4.0, 2.0, 6.0,
 		2.0, 5.0, 5.0,
 		6.0, 5.0, 14.0
-	}, 3, 3);
+	});
 
-	const auto b = lalib::DynMatD({ 
+	const auto b = lalib::DynMatD(3, 2, { 
         2.0, 0.0,
         5.0, 2.0, 
         1.0, -1.0
-    }, 3, 2);
+    });
 
 	{
 		auto cholesky = lalib::solver::DynModCholeskyFactorization(std::move(mat_sq));

--- a/test/solver/tri_diag.cc
+++ b/test/solver/tri_diag.cc
@@ -75,12 +75,12 @@ TEST(TriDiagSolverTests, DynMatLinearSolverTest) {
         { 2.0, 2.0, 2.0, 2.0 },
         { 1.0, 1.0, 1.0 }
     );
-    auto rhs = lalib::DynMat<double>({ 
+    auto rhs = lalib::DynMat<double>(4, 3, { 
         4.0, 2.0, 8.0,
         8.0, 4.0, 16.0,
         12.0, 6.0, 24.0,
         11.0, 5.5, 22.0
-    }, 4, 3);
+    });
     auto solver = lalib::solver::TriDiag(mat);
 
     solver.solve_linear(rhs, rhs);

--- a/test/vec/sized_vec.cc
+++ b/test/vec/sized_vec.cc
@@ -2,9 +2,30 @@
 #include <iterator>
 #include <ranges>
 #include <gtest/gtest.h>
+#include <stdexcept>
 
 //static_assert(std::random_access_iterator<typename lalib::SizedVec<uint32_t, 3>::Iter>);
 //static_assert(std::random_access_iterator<typename lalib::SizedVec<uint32_t, 3>::ConstIter>);
+
+TEST(SizedVecTests, VecConstTest) {
+    using VecU3 = lalib::SizedVec<uint32_t, 3>;
+    EXPECT_NO_THROW({
+        VecU3(std::vector<uint32_t>{0, 1, 2});
+    });
+    EXPECT_THROW({
+        VecU3(std::vector<uint32_t>{0, 1, 2, 3});
+    }, std::runtime_error);
+}
+
+TEST(SizedVecTests, InitListConstTest) {
+    using VecU3 = lalib::SizedVec<uint32_t, 3>;
+    EXPECT_NO_THROW({
+        VecU3({0, 1, 2});
+    });
+    EXPECT_THROW({
+        VecU3({0, 1, 2, 3});
+    }, std::runtime_error);
+}
 
 TEST(SizedVecTests, CopyConstTest) {
     auto vec = lalib::SizedVec<uint32_t, 3>({0, 1, 2});


### PR DESCRIPTION
# Overview 
This pull request allows the vectors and the matrices to be constructible with an initializer list.

The order of the arguments of the constructors for dynamic container such as `DynVec` and `DynMat` are changed.
The previous version of the constructors are still active but are marked as **deprecated** and will be removed in the next version.