### PR TITLE
Version 0.7.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(lalib VERSION 0.6.0 LANGUAGES C CXX)
+project(lalib VERSION 0.7.0 LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED True)

--- a/include/lalib/mat/sp_mat.hpp
+++ b/include/lalib/mat/sp_mat.hpp
@@ -100,6 +100,105 @@ private:
 };
 
 
+/// @brief Sparse matrix in compressed sparse row format
+template<typename T>
+struct SpMat {
+    using ElemType = T;
+
+    // ==== Initializations ==== //
+
+    /// @brief Create an empty sparse matrix object.
+    SpMat() noexcept = default;
+
+    /// @brief Create a sparse matrix from a COO matrix.
+    SpMat(const SpCooMat<T>& mat) noexcept;
+
+    /// @brief Create a sparse matrix from a COO matrix.
+    SpMat(SpCooMat<T>&& mat) noexcept;
+
+    /// @brief Create a sparse matrix with given data.
+    SpMat(const std::vector<T>& val, const std::vector<size_t>& row_ptr, const std::vector<size_t>& col_ids);
+
+    /// @brief Create a sparse matrix with given data.
+    SpMat(std::vector<T>&& val, std::vector<size_t>&& row_ptr, std::vector<size_t>&& col_ids);
+
+    /// @brief Copy constructor
+    SpMat(const SpMat<T>& mat) noexcept = default;
+
+    /// @brief Move constructor
+    SpMat(SpMat<T>&& mat) noexcept = default;
+
+
+    // === Inspecting === //
+
+    /// @brief Returns the shape of the matrix (row, column).
+    /// @return     a pair of size_t representing the shape of the matrix.
+    constexpr auto shape() const noexcept -> std::pair<size_t, size_t>;
+
+    /// @brief Returns the number of non-zero elements in the matrix.
+    /// @return     the number of non-zero elements.
+    constexpr auto nnz() const noexcept -> size_t;
+
+    /// @brief Returns the value of the element at the given position.
+    /// @param i    row index
+    /// @param j    column index
+    /// @return     the value of the element at the given position.
+    auto operator()(size_t i, size_t j) const noexcept -> const T&;
+
+
+    // === Modifying === //
+
+    /// @brief Reserves memory for the matrix.
+    /// @param n    the number of rows to reserve
+    /// @param nnz  the number of non-zero elements to reserve
+    void reserve(size_t n, size_t nnz) noexcept {
+        this->_val.reserve(nnz);
+        this->_row_ptr.reserve(n + 1);
+        this->_col_ids.reserve(nnz);
+    }
+
+
+    // === Assignment === //
+
+    /// @brief Replaces the elements of the vector.
+    /// @param mat the matrix to use as data source
+    /// @return a reference of the matrix after modified by the operation.
+    constexpr auto operator=(const SpMat<T>& mat) noexcept -> SpMat<T>&;
+
+    /// @brief Replaces the elements of the vector.
+    /// @param mat the matrix to use as data source
+    /// @return a reference of the matrix after modified by the operation.
+    constexpr auto operator=(SpMat<T>&& mat) noexcept -> SpMat<T>&;
+
+
+    // === Accessing === //
+
+    /// @brief Returns a pointer to the array of the values.
+    /// @return     a pointer to the array of the values.
+    auto values() const noexcept -> const std::vector<T>
+        { return this->_val; }
+    
+    /// @brief Returns a pointer to the array of the row pointers.
+    /// @return     a pointer to the array of the row pointers.
+    auto row_pointers() const noexcept -> const std::vector<size_t>
+        { return this->_row_ptr; }
+
+    /// @brief Returns a pointer to the array of the column indices.
+    /// @return     a pointer to the array of the column indices.
+    auto col_indices() const noexcept -> const std::vector<size_t>
+        { return this->_col_ids; }
+
+
+private:
+    std::vector<T> _val;
+    std::vector<size_t> _row_ptr;
+    std::vector<size_t> _col_ids;
+
+    const T _zero = Zero<T>::value();
+};
+
+
+// === COO Matrix === //
 // === Implementations === //
 
 template<typename T>
@@ -157,6 +256,102 @@ template<typename T>
 constexpr auto SpCooMat<T>::operator=(SpCooMat<T>&& mat) noexcept -> SpCooMat<T>& {
     this->_val = std::move(mat._val);
     this->_row_ids = std::move(mat._row_ids);
+    this->_col_ids = std::move(mat._col_ids);
+
+    return *this;
+}
+
+
+// === CSR Matrix === //
+// === Implementations === //
+
+inline void _convert_coo_crs(std::vector<size_t>& row_ptr, const std::vector<size_t>& row_ids) {
+    size_t nnz = row_ids.size();
+
+    row_ptr.reserve(nnz);
+    if (!row_ptr.empty()) {
+        row_ptr.clear();
+    }
+
+    row_ptr.emplace_back(0);
+
+    auto it = row_ids.begin();
+    for (size_t i = 0; it < row_ids.end(); ++i) {
+        it = std::upper_bound(it, row_ids.end(), i, std::less<size_t>{});
+        row_ptr.emplace_back(std::distance(row_ids.begin(), it));
+    }
+}
+
+template<typename T>
+SpMat<T>::SpMat(const SpCooMat<T>& mat) noexcept
+    : _val(mat.values()), _row_ptr(), _col_ids(mat.col_indices())
+{
+    _convert_coo_crs(this->_row_ptr, mat.row_indices());
+}
+
+template<typename T>
+SpMat<T>::SpMat(SpCooMat<T>&& mat) noexcept
+    : _val(std::move(mat.values())), _row_ptr(), _col_ids(std::move(mat.col_indices()))
+{
+    _convert_coo_crs(this->_row_ptr, mat.row_indices());
+}
+
+template<typename T>
+SpMat<T>::SpMat(const std::vector<T>& val, const std::vector<size_t>& row_ptr, const std::vector<size_t>& col_ids)
+    : _val(val), _row_ptr(row_ptr), _col_ids(col_ids) 
+{
+    if (this->_val.size() != this->_col_ids.size()) {
+        throw std::runtime_error("The size of the vectors must be the same.");
+    }
+}
+
+template<typename T>
+SpMat<T>::SpMat(std::vector<T>&& val, std::vector<size_t>&& row_ptr, std::vector<size_t>&& col_ids)
+    : _val(std::move(val)), _row_ptr(std::move(row_ptr)), _col_ids(std::move(col_ids))
+{
+    if (this->_val.size() != this->_col_ids.size()) {
+        throw std::runtime_error("The size of the vectors must be the same.");
+    }
+}
+
+
+
+template<typename T>
+constexpr auto SpMat<T>::shape() const noexcept -> std::pair<size_t, size_t> {
+    size_t nrow = this->_row_ptr.size() - 1;
+    size_t ncol = *std::ranges::max_element(this->_col_ids) + 1;
+
+    return std::make_pair(nrow, ncol);
+}
+
+template<typename T>
+constexpr auto SpMat<T>::nnz() const noexcept -> size_t {
+    return this->_val.size();
+}
+
+template<typename T>
+auto SpMat<T>::operator()(size_t i, size_t j) const noexcept -> const T& {
+    for (auto cnt: std::views::iota(this->_row_ptr[i], this->_row_ptr[i + 1])) {
+        if (this->_col_ids[cnt] == j) {
+            return this->_val[cnt];
+        }
+    }
+    return this->_zero;
+}
+
+template<typename T>
+constexpr auto SpMat<T>::operator=(const SpMat<T>& mat) noexcept -> SpMat<T>& {
+    this->_val = mat._val;
+    this->_row_ptr = mat._row_ptr;
+    this->_col_ids = mat._col_ids;
+
+    return *this;
+}
+
+template<typename T>
+constexpr auto SpMat<T>::operator=(SpMat<T>&& mat) noexcept -> SpMat<T>& {
+    this->_val = std::move(mat._val);
+    this->_row_ptr = std::move(mat._row_ptr);
     this->_col_ids = std::move(mat._col_ids);
 
     return *this;

--- a/include/lalib/mat/sp_mat.hpp
+++ b/include/lalib/mat/sp_mat.hpp
@@ -1,0 +1,166 @@
+#ifndef LALIB_MAT_SPARSE_MAT_HPP
+#define LALIB_MAT_SPARSE_MAT_HPP
+
+#include "lalib/ops/ops_traits.hpp"
+#include <algorithm>
+#include <vector>
+#include <cassert>
+#include <ranges>
+
+namespace lalib {
+
+/// @brief  Sparse matrix in coordinate format
+template<typename T>
+struct SpCooMat {
+    using ElemType = T; 
+
+    // ==== Initializations ==== //
+
+    /// @brief Create an empty sparse matrix object.
+    SpCooMat() noexcept = default;
+
+    /// @brief Create a sparse matrix with given data.
+    SpCooMat(const std::vector<T>& val, const std::vector<size_t>& row_ids, const std::vector<size_t>& col_ids);
+
+    /// @brief Create a sparse matrix with given data.
+    SpCooMat(std::vector<T>&& val, std::vector<size_t>&& row_ids, std::vector<size_t>&& col_ids);
+
+    /// @brief Copy constructor
+    SpCooMat(const SpCooMat<T>& mat) noexcept = default;
+
+    /// @brief Move constructor
+    SpCooMat(SpCooMat<T>&& mat) noexcept = default;
+
+
+    // === Inspecting === //
+
+    /// @brief Returns the shape of the matrix (row, column).
+    /// @return     a pair of size_t representing the shape of the matrix.
+    constexpr auto shape() const noexcept -> std::pair<size_t, size_t>;
+
+    /// @brief Returns the number of non-zero elements in the matrix.
+    /// @return     the number of non-zero elements.
+    constexpr auto nnz() const noexcept -> size_t;
+
+    /// @brief Returns the value of the element at the given position.
+    /// @param i    row index
+    /// @param j    column index
+    /// @return     the value of the element at the given position.
+    auto operator()(size_t i, size_t j) const noexcept -> const T&;
+
+
+    // === Modifying === //
+
+    /// @brief Reserves memory for the matrix.
+    /// @param n    the number of elements to reserve
+    void reserve(size_t n) noexcept {
+        this->_val.reserve(n);
+        this->_row_ids.reserve(n);
+        this->_col_ids.reserve(n);
+    }
+
+
+    // === Assignment === //
+
+    /// @brief Replaces the elements of the vector.
+    /// @param mat the matrix to use as data source
+    /// @return a reference of the matrix after modified by the operation.
+    constexpr auto operator=(const SpCooMat<T>& mat) noexcept -> SpCooMat<T>&;
+
+    /// @brief Replaces the elements of the vector.
+    /// @param mat the matrix to use as data source
+    /// @return a reference of the matrix after modified by the operation.
+    constexpr auto operator=(SpCooMat<T>&& mat) noexcept -> SpCooMat<T>&;
+
+
+    // === Accessing === //
+    
+    /// @brief Returns a pointer to the array of the values.
+    /// @return     a pointer to the array of the values.
+    auto values() const noexcept -> const std::vector<T>
+        { return this->_val; }
+
+    /// @brief Returns a pointer to the array of the row indices.
+    /// @return     a pointer to the array of the row indices.
+    auto row_indices() const noexcept -> const std::vector<size_t>
+        { return this->_row_ids; }
+
+    /// @brief Returns a pointer to the array of the column indices.
+    /// @return     a pointer to the array of the column indices.
+    auto col_indices() const noexcept -> const std::vector<size_t>
+        { return this->_col_ids; }
+
+
+private:
+    std::vector<T> _val;
+    std::vector<size_t> _row_ids;
+    std::vector<size_t> _col_ids;
+
+    const T _zero = Zero<T>::value();
+};
+
+
+// === Implementations === //
+
+template<typename T>
+SpCooMat<T>::SpCooMat(const std::vector<T>& val, const std::vector<size_t>& row_ids, const std::vector<size_t>& col_ids)
+    : _val(val), _row_ids(row_ids), _col_ids(col_ids) 
+{
+    if (this->_val.size() != this->_row_ids.size() || this->_val.size() != this->_col_ids.size()) {
+        throw std::runtime_error("The size of the vectors must be the same.");
+    }
+}
+
+template<typename T>
+SpCooMat<T>::SpCooMat(std::vector<T>&& val, std::vector<size_t>&& row_ids, std::vector<size_t>&& col_ids)
+    : _val(std::move(val)), _row_ids(std::move(row_ids)), _col_ids(std::move(col_ids))
+{
+    if (this->_val.size() != this->_row_ids.size() || this->_val.size() != this->_col_ids.size()) {
+        throw std::runtime_error("The size of the vectors must be the same.");
+    }
+}
+
+
+template<typename T>
+constexpr auto SpCooMat<T>::shape() const noexcept -> std::pair<size_t, size_t> {
+    size_t nrow = *std::ranges::max_element(this->_row_ids) + 1;
+    size_t ncol = *std::ranges::max_element(this->_col_ids) + 1;
+
+    return std::make_pair(nrow, ncol);
+}
+
+template<typename T>
+constexpr auto SpCooMat<T>::nnz() const noexcept -> size_t {
+    return this->_val.size();
+}
+
+template<typename T>
+auto SpCooMat<T>::operator()(size_t i, size_t j) const noexcept -> const T& {
+    for (auto cnt: std::views::iota(0u, this->_val.size())) {
+        if (this->_row_ids[cnt] == i && this->_col_ids[cnt] == j) {
+            return this->_val[cnt];
+        }
+    }
+    return this->_zero;
+}
+
+template<typename T>
+constexpr auto SpCooMat<T>::operator=(const SpCooMat<T>& mat) noexcept -> SpCooMat<T>& {
+    this->_val = mat._val;
+    this->_row_ids = mat._row_ids;
+    this->_col_ids = mat._col_ids;
+
+    return *this;
+}
+
+template<typename T>
+constexpr auto SpCooMat<T>::operator=(SpCooMat<T>&& mat) noexcept -> SpCooMat<T>& {
+    this->_val = std::move(mat._val);
+    this->_row_ids = std::move(mat._row_ids);
+    this->_col_ids = std::move(mat._col_ids);
+
+    return *this;
+}
+
+}
+#endif

--- a/include/lalib/mat/sp_mat.hpp
+++ b/include/lalib/mat/sp_mat.hpp
@@ -190,7 +190,7 @@ struct SpMat {
     
     /// @brief Returns a pointer to the array of the row pointers.
     /// @return     a pointer to the array of the row pointers.
-    auto row_pointers() const noexcept -> const std::vector<size_t>&
+    auto row_ptr() const noexcept -> const std::vector<size_t>&
         { return this->_row_ptr; }
 
     /// @brief Returns a pointer to the array of the column indices.

--- a/include/lalib/mat/sp_mat.hpp
+++ b/include/lalib/mat/sp_mat.hpp
@@ -74,20 +74,25 @@ struct SpCooMat {
 
 
     // === Accessing === //
-    
+
     /// @brief Returns a pointer to the array of the values.
     /// @return     a pointer to the array of the values.
-    auto values() const noexcept -> const std::vector<T>
+    auto data() noexcept -> T*
+        { return this->_val.data(); }
+    
+    /// @brief Returns a reference to the array of the values.
+    /// @return     a pointer to the array of the values.
+    auto values() const noexcept -> const std::vector<T>&
         { return this->_val; }
 
-    /// @brief Returns a pointer to the array of the row indices.
+    /// @brief Returns a reference to the array of the row indices.
     /// @return     a pointer to the array of the row indices.
-    auto row_indices() const noexcept -> const std::vector<size_t>
+    auto row_indices() const noexcept -> const std::vector<size_t>&
         { return this->_row_ids; }
 
-    /// @brief Returns a pointer to the array of the column indices.
+    /// @brief Returns a reference to the array of the column indices.
     /// @return     a pointer to the array of the column indices.
-    auto col_indices() const noexcept -> const std::vector<size_t>
+    auto col_indices() const noexcept -> const std::vector<size_t>&
         { return this->_col_ids; }
 
 
@@ -175,17 +180,22 @@ struct SpMat {
 
     /// @brief Returns a pointer to the array of the values.
     /// @return     a pointer to the array of the values.
-    auto values() const noexcept -> const std::vector<T>
+    auto data() noexcept -> T*
+        { return this->_val.data(); }
+
+    /// @brief Returns a reference to the array of the values.
+    /// @return     a pointer to the array of the values.
+    auto values() const noexcept -> const std::vector<T>&
         { return this->_val; }
     
     /// @brief Returns a pointer to the array of the row pointers.
     /// @return     a pointer to the array of the row pointers.
-    auto row_pointers() const noexcept -> const std::vector<size_t>
+    auto row_pointers() const noexcept -> const std::vector<size_t>&
         { return this->_row_ptr; }
 
     /// @brief Returns a pointer to the array of the column indices.
     /// @return     a pointer to the array of the column indices.
-    auto col_indices() const noexcept -> const std::vector<size_t>
+    auto col_indices() const noexcept -> const std::vector<size_t>&
         { return this->_col_ids; }
 
 

--- a/include/lalib/ops/mat_ops.hpp
+++ b/include/lalib/ops/mat_ops.hpp
@@ -5,21 +5,32 @@
 
 #include "lalib/mat/sized_mat.hpp"
 #include "lalib/mat/dyn_mat.hpp"
+#include "lalib/mat/sp_mat.hpp"
 #include "vec_ops_core.hpp"
 
 namespace lalib {
 
+// =============== //
+//  SCALE          //
+// =============== //
+
 template<typename T, size_t N, size_t M>
-inline auto scale(const T& alpha, SizedMat<T, N, M>& mat) noexcept -> SizedMat<T, N, M> {
+inline auto scale(const T& alpha, SizedMat<T, N, M>& mat) noexcept -> SizedMat<T, N, M>& {
     auto [n, m] = mat.shape();
     scal_core(alpha, mat.data(), n * m);
     return mat;
 }
 
 template<typename T>
-inline auto scale(const T& alpha, DynMat<T>& mat) noexcept -> DynMat<T> {
+inline auto scale(const T& alpha, DynMat<T>& mat) noexcept -> DynMat<T>& {
     auto [n, m] = mat.shape();
     scal_core(alpha, mat.data(), n * m);
+    return mat;
+}
+
+template<typename T>
+inline auto scale(const T& alpha, SpMat<T>& mat) noexcept -> SpMat<T>& {
+    scal_core<T>(alpha, mat.data(), mat.nnz());
     return mat;
 }
 
@@ -38,6 +49,18 @@ inline auto operator*(const T& alpha, const DynMat<T>& mat) noexcept -> DynMat<T
     return rmat;
 }
 
+template<typename T>
+inline auto operator*(const T& alpha, const SpMat<T>& mat) noexcept -> SpMat<T> {
+    auto rmat = mat;
+    scale(alpha, rmat);
+    return rmat;
+}
+
+
+// =============== //
+//  NEGATION       //
+// =============== //
+
 template<typename T, size_t N, size_t M>
 requires std::is_integral_v<T> || std::is_floating_point_v<T>
 inline auto operator-(const SizedMat<T, N, M>& mat) noexcept -> SizedMat<T, N, M> {
@@ -49,6 +72,14 @@ inline auto operator-(const SizedMat<T, N, M>& mat) noexcept -> SizedMat<T, N, M
 template<typename T>
 requires std::is_integral_v<T> || std::is_floating_point_v<T>
 inline auto operator-(const DynMat<T>& mat) noexcept -> DynMat<T> {
+    auto rmat = mat;
+    scale(-1.0, rmat);
+    return rmat;
+}
+
+template<typename T>
+requires std::is_integral_v<T> || std::is_floating_point_v<T>
+inline auto operator-(const SpMat<T>& mat) noexcept -> SpMat<T> {
     auto rmat = mat;
     scale(-1.0, rmat);
     return rmat;

--- a/include/lalib/ops/mat_vec_ops.hpp
+++ b/include/lalib/ops/mat_vec_ops.hpp
@@ -5,6 +5,7 @@
 #include "mat_vec_ops_core.hpp"
 #include "lalib/mat/sized_mat.hpp"
 #include "lalib/mat/dyn_mat.hpp"
+#include "lalib/mat/sp_mat.hpp"
 #include "lalib/vec/sized_vec.hpp"
 #include "lalib/vec/dyn_vec.hpp"
 #include <cassert>
@@ -45,6 +46,15 @@ inline auto mul(T alpha, const DynMat<T>& mat, const DynVec<T>& v, T beta, DynVe
     return vr;
 }
 
+template<typename T>
+inline auto mul(T alpha, const SpMat<T>& mat, const DynVec<T>& v, T beta, DynVec<T>& vr) noexcept -> DynVec<T>& {
+    auto [n, m] = mat.shape();
+    assert(m == v.size());
+    assert(n == vr.size());
+    _sp_mul_core(n, mat.col_indices().data(), mat.row_ptr().data(), alpha, mat.values().data(), v.data(), beta, vr.data());
+    return vr;
+}
+
 
 template<typename T, size_t N, size_t M>
 inline auto operator*(const SizedMat<T, N, M>& mat, const SizedVec<T, M>& vec) noexcept -> SizedVec<T, N> {
@@ -76,6 +86,15 @@ inline auto operator*(const DynMat<T>& mat, const DynVec<T>& vec) noexcept -> Dy
     assert(m == vec.size());
     auto vr = DynVec<T>::uninit(n);
     mul_core(n, m, 1.0, mat.data(), vec.data(), 0.0, vr.data());
+    return vr;
+}
+
+template<typename T>
+inline auto operator*(const SpMat<T>& mat, const DynVec<T>& vec) noexcept -> DynVec<T> {
+    auto [n, m] = mat.shape();
+    assert(m == vec.size());
+    auto vr = DynVec<T>::uninit(n);
+    _sp_mul_core(n, mat.col_indices().data(), mat.row_ptr().data(), 1.0, mat.values().data(), vec.data(), 0.0, vr.data());
     return vr;
 }
 

--- a/include/lalib/ops/mat_vec_ops_core.hpp
+++ b/include/lalib/ops/mat_vec_ops_core.hpp
@@ -52,6 +52,18 @@ inline auto __mul_core_simd(size_t n, size_t m, T alpha, const T* mat, const T* 
 }
 
 template<typename T>
+inline auto _sp_mul_core(size_t n, const size_t* col_ids, const size_t* row_ptr, T alpha, const T* mat, const T* x, T beta, T* y) noexcept -> T* {
+    #pragma omp simd
+    for (auto i = 0u; i < n; ++i) {
+        y[i] = beta * y[i];
+        for (auto k = row_ptr[i]; k < row_ptr[i + 1]; ++k) {
+            y[i] += alpha * mat[k] * x[col_ids[k]];
+        }
+    }
+    return y;
+}
+
+template<typename T>
 inline auto mul_core(size_t n, size_t m, T alpha, const T* mat, const T* x, T beta, T* y) noexcept -> T* {
     __mul_core_simd(n, m, alpha, mat, x, beta, y);
     return y;
@@ -86,6 +98,12 @@ inline auto mul_core<double>(size_t n, size_t m, double alpha, const double* mat
     #else
     __mul_core_simd(n, m, alpha, mat, x, beta, y);
     #endif
+    return y;
+}
+
+template<typename T>
+inline auto sp_mul_core(size_t n, const size_t* col_ids, const size_t* row_ptr, T alpha, const T* mat, const T* x, T beta, T* y) noexcept -> T* {
+    _sp_mul_core(n, col_ids, row_ptr, alpha, mat, x, beta, y);
     return y;
 }
 

--- a/include/lalib/solver/gmres.hpp
+++ b/include/lalib/solver/gmres.hpp
@@ -1,0 +1,148 @@
+#ifndef LALIB_SOLVER_GMRES_HPP
+#define LALIB_SOLVER_GMRES_HPP
+
+#include "lalib/mat/dyn_mat.hpp"
+#include "lalib/ops/ops_traits.hpp"
+#include "lalib/vec/dyn_vec.hpp" 
+#include "lalib/ops/vec_ops.hpp"
+#include "lalib/ops/mat_vec_ops.hpp"
+#include <ranges>
+
+namespace lalib::solver {
+
+/// @brief      GMRES solver
+/// @tparam T   a floating-point type
+/// @tparam M   a matrix type
+template<typename T, typename M>
+struct Gmres {
+    /// @brief      Constructs a GMRES solver
+    /// @param mat  a matrix
+    /// @param tol  a tolerance
+    Gmres(const M& mat, T tol): _mat(mat), _tol(tol) {}
+
+    /// @brief      Solves a linear system
+    /// @param rhs  a right-hand side vector
+    /// @return     a solution vector
+    auto solve(const lalib::DynVec<T>& rhs) const -> lalib::DynVec<T>;
+
+private:
+    const M _mat;
+    const T _tol;
+
+    void _arnoldi(std::vector<DynVec<T>>& q, HessenbergMat<T>& hess, T& h) const;
+    void _givens_rot(const HessenbergMat<T>& hess, T h, std::vector<T>& s, std::vector<T>& c, DynUpperTriMat<T>& r, std::vector<T>& beta) const;
+};
+
+
+// === Implementation === //
+
+template<typename T, typename M>
+auto Gmres<T, M>::solve(const lalib::DynVec<T>& rhs) const -> lalib::DynVec<T> {
+    auto n = this->_mat.shape().first;
+
+    // Krylov subspace basis
+    auto q = std::vector<lalib::DynVec<T>>();
+    q.reserve(n);
+    
+    // Initial Krylov subspace basis
+    q.emplace_back((1.0 / rhs.norm2()) * rhs);
+
+    // Givens rotation components
+    auto c = std::vector<T>();
+    auto s = std::vector<T>();
+    c.reserve(n);
+    s.reserve(n);
+
+    // Beta vector ( beta = ||b||| U^T e_1 )
+    auto beta = std::vector<T>();
+    beta.reserve(n);
+    beta.emplace_back(rhs.norm2());
+
+    auto r = DynUpperTriMat<T>::with_capacity(n);
+    auto hess = HessenbergMat<T>::with_capacity(n);
+    auto h = Zero<T>::value();
+
+    // Start the GMRES iteration
+    for ([[maybe_unused]] auto i: std::views::iota(0u, n)) {
+        // Extend the Krylob subspace
+        this->_arnoldi(q, hess, h);
+        this->_givens_rot(hess, h, s, c, r, beta);
+
+        // Check the convergence
+        if (std::abs(beta.back()) < this->_tol) { break; }
+    }
+
+    // Solve the uper triangle system
+    auto bend = beta.size() - 1;
+    r.back_sub(beta | std::views::take(bend));
+
+    // Transform the solution from the Krylov subspace
+    auto x = lalib::DynVec<T>::filled(n, Zero<T>::value());
+    for (auto i = 0u; i < n; ++i) {
+        axpy(1.0, beta[i] * q[i], x);
+    }
+
+    return x;
+}
+
+
+template<typename T, typename M>
+void Gmres<T, M>::_arnoldi(std::vector<DynVec<T>>& q, HessenbergMat<T>& hess, T& h) const {
+    auto i = q.size() - 1;
+
+    // Extend the Hessenberg matrix
+    hess.extend_with_zero();
+    if (i > 0) {
+        hess(i, i - 1) = h;
+    }
+    assert(hess.shape().first == i + 1);
+
+    auto v = this->_mat * q[i];
+    for (auto j: std::views::iota(0u, i + 1)) {
+        hess(j, i) = dot(q[j], v);
+    }
+    for (auto j: std::views::iota(0u, i + 1)) {
+        axpy(-1.0, hess(j, i) * q[j], v);
+    }
+
+    h = v.norm2();
+    q.emplace_back((1.0 / h) * v);
+}
+
+template<typename T, typename M>
+void Gmres<T, M>::_givens_rot(const HessenbergMat<T>& hess, T h, std::vector<T>& s, std::vector<T>& c, DynUpperTriMat<T>& r, std::vector<T>& beta) const {
+    auto n = hess.shape().first;
+
+    // Extend the upper triangular matrix
+    auto col = hess.get_col(n - 1);
+    r.extend_with(std::vector(col.begin(), col.end()));
+    assert(r.shape().first == n);
+
+    // Extend the beta vector
+    beta.emplace_back(Zero<T>::value());
+    assert(beta.size() == n+1);
+
+    // Calculate the extended components of the upper triangle matrix
+    for (auto i: std::views::iota(0u, n - 1)) {
+        auto tmp = c[i] * r(i, n-1) + s[i] * hess(i+1, n-1);
+        r(i+1, n-1) = -s[i] * r(i, n-1) + c[i] * hess(i+1, n-1);
+        r(i, n-1) = tmp;
+    }
+
+    // Calculate the Givens rotation
+    auto delta  = std::sqrt(std::pow(r(n-1, n-1), 2) + std::pow(h, 2));
+    s.emplace_back(h / delta);
+    c.emplace_back(r(n-1, n-1) / delta);
+    assert(c.size() == n);
+    assert(s.size() == n);
+
+    // Calculate beta = ||b||| U^T e_1
+    beta[n] = -s[n-1] * beta[n-1];
+    beta[n-1] = c[n-1] * beta[n-1];
+
+    // Apply the Givens rotations to the Hessenberg matrix
+    r(n-1, n-1) = c[n-1] * r(n-1, n-1) + s[n-1] * h;
+}
+
+}
+#endif

--- a/include/lalib/vec/dyn_vec.hpp
+++ b/include/lalib/vec/dyn_vec.hpp
@@ -21,6 +21,9 @@ public:
 
     // === Initializations === //
 
+    /// @brief Create an empty dynamic-sized vector.
+    constexpr DynVec() noexcept = default;
+
     /// @brief Create a sized vector with given array with copy.
     constexpr DynVec(const std::vector<T>& vec) noexcept: 
         _elems(vec) {}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,6 +20,9 @@ add_executable(lalib_com_mat_test mat/common_mat.cc)
 target_link_libraries(lalib_com_mat_test PRIVATE ${BLAS_LIBRARIES} ${OpenMP_CXX_LIBRARIES} GTest::GTest GTest::Main)
 gtest_discover_tests(lalib_com_mat_test)
 
+add_executable(lalib_sp_mat_test mat/sp_mat.cc)
+target_link_libraries(lalib_sp_mat_test PRIVATE ${BLAS_LIBRARIES} ${OpenMP_CXX_LIBRARIES} GTest::GTest GTest::Main)
+gtest_discover_tests(lalib_sp_mat_test)
 
 
 ## Vector Operations

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -70,6 +70,15 @@ target_link_libraries(lalib_cholesky_decomposition_test PRIVATE
 )
 gtest_discover_tests(lalib_cholesky_decomposition_test)
 
+add_executable(lalib_gmres_test solver/gmres.cc)
+target_link_libraries(lalib_gmres_test PRIVATE 
+    $<$<BOOL:${LAPACK_FOUND}>:LAPACK::LAPACK> 
+    $<$<BOOL:${LAPACK_FOUND}>:-llapacke>
+    ${BLAS_LIBRARIES} ${OpenMP_CXX_LIBRARIES} 
+    GTest::GTest GTest::Main
+)
+gtest_discover_tests(lalib_gmres_test)
+
 
 ## Errors
 add_executable(lalib_error_test err/error.cc)

--- a/test/mat/dyn_mat.cc
+++ b/test/mat/dyn_mat.cc
@@ -57,7 +57,7 @@ TEST(DynMatTests, FilledTest) {
     }
 }
 
-TEST(SizedMatTests, DiagTest) {
+TEST(DynMatTests, DiagTest) {
     auto n_rows = 5u;
     auto mat1 = lalib::DynMat<double>::diag(2.0, n_rows);
     auto mat2 = lalib::DynMat<double>::diag({1.0, 2.0 ,3.0, 4.0, 5.0});
@@ -76,4 +76,129 @@ TEST(SizedMatTests, DiagTest) {
             else        ASSERT_DOUBLE_EQ(0.0, mat2(i, j));
         }
     }
+}
+
+TEST(DynMatTests, HessenbergMatTest) {
+    /*
+        * 1.0 3.0 6.0
+        * 2.0 4.0 7.0
+        * 0.0 5.0 8.0 
+    */
+    const auto mat = lalib::HessenbergMat<double>(
+        std::vector<double>({1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0})
+    );
+
+    ASSERT_DOUBLE_EQ(1.0, mat(0, 0));
+    ASSERT_DOUBLE_EQ(3.0, mat(0, 1));
+    ASSERT_DOUBLE_EQ(6.0, mat(0, 2));
+    ASSERT_DOUBLE_EQ(2.0, mat(1, 0));
+    ASSERT_DOUBLE_EQ(4.0, mat(1, 1));
+    ASSERT_DOUBLE_EQ(7.0, mat(1, 2));
+    ASSERT_DOUBLE_EQ(0.0, mat(2, 0));
+    ASSERT_DOUBLE_EQ(5.0, mat(2, 1));
+    ASSERT_DOUBLE_EQ(8.0, mat(2, 2));
+}
+
+TEST(DynMatTests, HessenbergMatExtendTest) {
+    auto hess1 = lalib::HessenbergMat<double>({0.0});
+
+    hess1.extend_with_zero();
+
+    ASSERT_DOUBLE_EQ(2, hess1.shape().first);
+    ASSERT_DOUBLE_EQ(2, hess1.shape().second);
+
+    hess1.extend_with({1.0, 2.0, 3.0, 4.0});
+    ASSERT_DOUBLE_EQ(3, hess1.shape().first);
+    ASSERT_DOUBLE_EQ(3, hess1.shape().second);
+
+
+    const auto hess = hess1;
+
+    ASSERT_DOUBLE_EQ(0.0, hess(0, 0));
+    ASSERT_DOUBLE_EQ(0.0, hess(0, 1));
+    ASSERT_DOUBLE_EQ(2.0, hess(0, 2));
+    ASSERT_DOUBLE_EQ(0.0, hess(1, 0));
+    ASSERT_DOUBLE_EQ(0.0, hess(1, 1));
+    ASSERT_DOUBLE_EQ(3.0, hess(1, 2));
+    ASSERT_DOUBLE_EQ(0.0, hess(2, 0));
+    ASSERT_DOUBLE_EQ(1.0, hess(2, 1));
+    ASSERT_DOUBLE_EQ(4.0, hess(2, 2));
+}
+
+TEST(DynMatTests, HessenbergMatGetColTest) {
+    auto hess = lalib::HessenbergMat<double>({1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0});
+
+    auto col0 = hess.get_col(0);
+    ASSERT_EQ(2, col0.size());
+    ASSERT_DOUBLE_EQ(1.0, col0[0]);
+    ASSERT_DOUBLE_EQ(2.0, col0[1]);
+
+    auto col1 = hess.get_col(1);
+    ASSERT_EQ(3, col1.size());
+    ASSERT_DOUBLE_EQ(3.0, col1[0]);
+    ASSERT_DOUBLE_EQ(4.0, col1[1]);
+    ASSERT_DOUBLE_EQ(5.0, col1[2]);
+
+    auto col2 = hess.get_col(2);
+    ASSERT_EQ(3, col2.size());
+    ASSERT_DOUBLE_EQ(6.0, col2[0]);
+    ASSERT_DOUBLE_EQ(7.0, col2[1]);
+    ASSERT_DOUBLE_EQ(8.0, col2[2]);
+}
+
+TEST(DynMatTests, DynUpperTriMatTest) {
+    /*
+        * 1.0 2.0 4.0
+        * 0.0 3.0 5.0
+        * 0.0 0.0 6.0 
+    */
+    const auto mat = lalib::DynUpperTriMat<double>(
+        std::vector<double>({1.0, 2.0, 3.0, 4.0, 5.0, 6.0})
+    );
+
+    ASSERT_DOUBLE_EQ(1.0, mat(0, 0));
+    ASSERT_DOUBLE_EQ(2.0, mat(0, 1));
+    ASSERT_DOUBLE_EQ(4.0, mat(0, 2));
+    ASSERT_DOUBLE_EQ(0.0, mat(1, 0));
+    ASSERT_DOUBLE_EQ(3.0, mat(1, 1));
+    ASSERT_DOUBLE_EQ(5.0, mat(1, 2));
+    ASSERT_DOUBLE_EQ(0.0, mat(2, 0));
+    ASSERT_DOUBLE_EQ(0.0, mat(2, 1));
+    ASSERT_DOUBLE_EQ(6.0, mat(2, 2));
+}
+
+TEST(DynMatTests, DynUpperTriMatExtendTest) {
+    auto tri1 = lalib::DynUpperTriMat<double>({0.0});
+
+    tri1.extend_with_zero();
+
+    ASSERT_DOUBLE_EQ(2, tri1.shape().first);
+    ASSERT_DOUBLE_EQ(2, tri1.shape().second);
+
+    tri1.extend_with(std::vector<double>({1.0, 2.0, 3.0}));
+    ASSERT_DOUBLE_EQ(3, tri1.shape().first);
+    ASSERT_DOUBLE_EQ(3, tri1.shape().second);
+
+
+    const auto tri = tri1;
+    ASSERT_DOUBLE_EQ(0.0, tri(0, 0));
+    ASSERT_DOUBLE_EQ(0.0, tri(0, 1));
+    ASSERT_DOUBLE_EQ(1.0, tri(0, 2));
+    ASSERT_DOUBLE_EQ(0.0, tri(1, 0));
+    ASSERT_DOUBLE_EQ(0.0, tri(1, 1));
+    ASSERT_DOUBLE_EQ(2.0, tri(1, 2));
+    ASSERT_DOUBLE_EQ(0.0, tri(2, 0));
+    ASSERT_DOUBLE_EQ(0.0, tri(2, 1));
+    ASSERT_DOUBLE_EQ(3.0, tri(2, 2));
+}
+
+TEST(DynMatTests, DynUpperTriMatBackSubTest) {
+    auto tri = lalib::DynUpperTriMat<double>({1.0, 0.5, 1.0, 0.5, 2.0, 1.0});
+    auto y = std::vector<double>({4.5, 4.0, 1.0});
+
+    tri.back_sub(y);
+
+    ASSERT_DOUBLE_EQ(3.0, y[0]);
+    ASSERT_DOUBLE_EQ(2.0, y[1]);
+    ASSERT_DOUBLE_EQ(1.0, y[2]);
 }

--- a/test/mat/sp_mat.cc
+++ b/test/mat/sp_mat.cc
@@ -1,0 +1,102 @@
+#include "lalib/mat/sp_mat.hpp"
+#include <gtest/gtest.h>
+
+TEST(SpMatTests, SpCooMatCreationTest) {
+    using SpCooMatD = lalib::SpCooMat<double>;
+
+    EXPECT_NO_THROW({
+        SpCooMatD(
+            { 1.0, 2.0, 3.0, 4.0 },
+            { 0, 0, 1, 1 },
+            { 0, 1, 0, 1 }
+        );
+    });
+
+    EXPECT_THROW({
+        SpCooMatD(
+            { 1.0, 2.0, 3.0, 4.0 },
+            { 0, 0, 1, 1 },
+            { 0, 1, 0 }
+        );
+    }, std::runtime_error);
+
+    EXPECT_THROW({
+        SpCooMatD(
+            { 1.0, 2.0, 3.0, 4.0 },
+            { 0, 0, 1, 1 },
+            { 0, 1, 0, 1, 2 }
+        );
+    }, std::runtime_error);
+
+    EXPECT_THROW({
+        SpCooMatD(
+            { 1.0, 2.0, 3.0, 4.0 },
+            { 0, 0, 1, 1, 2 },
+            { 0, 1, 0, 1 }
+        );
+    }, std::runtime_error);
+
+    EXPECT_THROW({
+        SpCooMatD(
+            { 1.0, 2.0, 3.0, 4.0, 5.0 },
+            { 0, 0, 1, 1 },
+            { 0, 1, 0, 1 }
+        );
+    }, std::runtime_error);
+}
+
+TEST(SpMatTests, SpCooMatCopyTest) {
+    auto mat = lalib::SpCooMat<double> {
+        { 1.0, 2.0, 3.0, 4.0 },
+        { 0, 0, 1, 1 },
+        { 0, 1, 0, 1 }
+    };
+
+    auto mat_copy = mat;
+
+    ASSERT_EQ(mat_copy(0, 0), mat(0, 0));
+    ASSERT_EQ(mat_copy(0, 1), mat(0, 1));
+    ASSERT_EQ(mat_copy(1, 0), mat(1, 0));
+    ASSERT_EQ(mat_copy(1, 1), mat(1, 1));
+}
+
+TEST(SpMatTests, SpCooMatCopyAssignTest) {
+    auto mat = lalib::SpCooMat<double> {
+        { 1.0, 2.0, 3.0, 4.0 },
+        { 0, 0, 1, 1 },
+        { 0, 1, 0, 1 }
+    };
+    auto mat_copy = lalib::SpCooMat<double> {};
+
+    mat_copy = mat;
+
+    ASSERT_EQ(mat_copy(0, 0), mat(0, 0));
+    ASSERT_EQ(mat_copy(0, 1), mat(0, 1));
+    ASSERT_EQ(mat_copy(1, 0), mat(1, 0));
+    ASSERT_EQ(mat_copy(1, 1), mat(1, 1));
+}
+
+TEST(SpMatTests, SpCooMatShapeTest) {
+    auto mat = lalib::SpCooMat<double> {
+        { 1.0, 2.0, 3.0, 4.0 },
+        { 0, 0, 1, 1 },
+        { 0, 1, 0, 1 }
+    };
+
+    auto shape = mat.shape();
+
+    ASSERT_EQ(shape.first, 2);
+    ASSERT_EQ(shape.second, 2);
+}
+
+TEST(SpMatTests, SpCooMatNnzTest) {
+    auto mat = lalib::SpCooMat<double> {
+        { 1.0, 2.0, 3.0, 4.0 },
+        { 0, 0, 1, 1 },
+        { 0, 1, 0, 1 }
+    };
+
+    auto nnz = mat.nnz();
+
+    ASSERT_EQ(nnz, 4);
+}

--- a/test/mat/sp_mat.cc
+++ b/test/mat/sp_mat.cc
@@ -100,3 +100,126 @@ TEST(SpMatTests, SpCooMatNnzTest) {
 
     ASSERT_EQ(nnz, 4);
 }
+
+
+// === CSR Matrix === //
+
+TEST(SpMatTests, SpMatCreationTest) {
+    using SpMatD = lalib::SpMat<double>;
+
+    EXPECT_NO_THROW({
+        SpMatD(
+            { 1.0, 2.0, 3.0, 4.0 },
+            { 0, 2, 4 },
+            { 0, 1, 0, 1 }
+        );
+    });
+
+    /* ------------- */
+    /* 1.0  2.0  0.0 */
+    /* 3.0  0.0  0.0 */
+    /* 0.0  4.0  5.0 */
+    /* ------------- */
+    EXPECT_NO_THROW({
+        SpMatD(
+            { 1.0, 2.0, 3.0, 4.0, 5.0 },
+            { 0, 2, 3, 5 },
+            { 0, 1, 0, 1, 2 }
+        );
+    });
+
+    EXPECT_THROW({
+        SpMatD(
+            { 1.0, 2.0, 3.0, 4.0 },
+            { 0, 2, 4 },
+            { 0, 1, 0 }
+        );
+    }, std::runtime_error);
+}
+
+TEST(SpMatTests, SpMatCopyTest) {
+    auto mat = lalib::SpMat<double> {
+        { 1.0, 2.0, 3.0, 4.0 },
+        { 0, 2, 4 },
+        { 0, 1, 0, 1 }
+    };
+
+    auto mat_copy = mat;
+
+    ASSERT_EQ(mat_copy(0, 0), mat(0, 0));
+    ASSERT_EQ(mat_copy(0, 1), mat(0, 1));
+    ASSERT_EQ(mat_copy(1, 0), mat(1, 0));
+    ASSERT_EQ(mat_copy(1, 1), mat(1, 1));
+}
+
+TEST(SpMatTests, SpMatCopyAssignTest) {
+    auto mat = lalib::SpMat<double> {
+        { 1.0, 2.0, 3.0, 4.0 },
+        { 0, 2, 4 },
+        { 0, 1, 0, 1 }
+    };
+    auto mat_copy = lalib::SpMat<double> {};
+
+    mat_copy = mat;
+
+    ASSERT_EQ(mat_copy(0, 0), mat(0, 0));
+    ASSERT_EQ(mat_copy(0, 1), mat(0, 1));
+    ASSERT_EQ(mat_copy(1, 0), mat(1, 0));
+    ASSERT_EQ(mat_copy(1, 1), mat(1, 1));
+}
+
+TEST(SpMatTests, SpMatShapeTest) {
+    auto mat = lalib::SpMat<double>(
+        { 1.0, 2.0, 3.0, 4.0, 5.0 },
+        { 0, 2, 3, 5 },
+        { 0, 1, 0, 1, 2 }
+    );
+
+    auto shape = mat.shape();
+
+    ASSERT_EQ(shape.first, 3);
+    ASSERT_EQ(shape.second, 3);
+}
+
+TEST(SpMatTests, SpMatNnzTest) {
+    auto mat = lalib::SpMat<double> {
+        { 1.0, 2.0, 3.0, 4.0 },
+        { 0, 2, 4 },
+        { 0, 1, 0, 1 }
+    };
+
+    auto nnz = mat.nnz();
+
+    ASSERT_EQ(nnz, 4);
+}
+
+TEST(SpMatTests, CooCrsConversionTest) {
+    auto coo_mat = lalib::SpCooMat<double> {
+        { 1.0, 2.0, 3.0, 4.0, 5.0 },
+        { 0, 0, 1, 2, 2 },
+        { 0, 1, 0, 1, 2 }
+    };
+
+    auto crs_mat = lalib::SpMat<double>(coo_mat);
+    auto crs_mat_moved = lalib::SpMat<double>(std::move(coo_mat));
+
+    ASSERT_EQ(crs_mat(0, 0), 1.0);
+    ASSERT_EQ(crs_mat(0, 1), 2.0);
+    ASSERT_EQ(crs_mat(0, 2), 0.0);
+    ASSERT_EQ(crs_mat(1, 0), 3.0);
+    ASSERT_EQ(crs_mat(1, 1), 0.0);
+    ASSERT_EQ(crs_mat(1, 2), 0.0);
+    ASSERT_EQ(crs_mat(2, 0), 0.0);
+    ASSERT_EQ(crs_mat(2, 1), 4.0);
+    ASSERT_EQ(crs_mat(2, 2), 5.0);
+
+    ASSERT_EQ(crs_mat_moved(0, 0), 1.0);
+    ASSERT_EQ(crs_mat_moved(0, 1), 2.0);
+    ASSERT_EQ(crs_mat_moved(0, 2), 0.0);
+    ASSERT_EQ(crs_mat_moved(1, 0), 3.0);
+    ASSERT_EQ(crs_mat_moved(1, 1), 0.0);
+    ASSERT_EQ(crs_mat_moved(1, 2), 0.0);
+    ASSERT_EQ(crs_mat_moved(2, 0), 0.0);
+    ASSERT_EQ(crs_mat_moved(2, 1), 4.0);
+    ASSERT_EQ(crs_mat_moved(2, 2), 5.0);
+}

--- a/test/ops/mat_ops.cc
+++ b/test/ops/mat_ops.cc
@@ -22,3 +22,29 @@ TEST(MatOpsTest, ScaleTest) {
     EXPECT_DOUBLE_EQ(10.0, rmat(1, 1));
     EXPECT_DOUBLE_EQ(12.0, rmat(1, 2));
 }
+
+TEST(MatOpsTests, SpScaleTest) {
+    auto mat = lalib::SpMat<double>(
+        { 1.0, 2.0, 3.0, 4.0 },
+        { 0, 2, 4 },
+        { 0, 1, 0, 1 }
+    );
+    scale(2.0, mat);
+
+    EXPECT_DOUBLE_EQ(2.0, mat(0, 0));
+    EXPECT_DOUBLE_EQ(4.0, mat(0, 1));
+    EXPECT_DOUBLE_EQ(6.0, mat(1, 0));
+    EXPECT_DOUBLE_EQ(8.0, mat(1, 1));
+
+    auto mat2 = lalib::SpMat<double>(
+        { 1.0, 2.0, 3.0, 4.0 },
+        { 0, 2, 4 },
+        { 0, 1, 0, 1 }
+    );
+    auto rmat = 2.0 * mat2;
+
+    EXPECT_DOUBLE_EQ(2.0, rmat(0, 0));
+    EXPECT_DOUBLE_EQ(4.0, rmat(0, 1));
+    EXPECT_DOUBLE_EQ(6.0, rmat(1, 0));
+    EXPECT_DOUBLE_EQ(8.0, rmat(1, 1));
+}

--- a/test/ops/mat_vec_ops.cc
+++ b/test/ops/mat_vec_ops.cc
@@ -79,3 +79,27 @@ TEST(MatVecOpsTests, SizedMatSizedVecMulAssignTest) {
     EXPECT_DOUBLE_EQ(8.0, v[0]);
     EXPECT_DOUBLE_EQ(16.0, v[1]);
 }
+
+TEST(MatVecOpsTests, SpMatDynVecMulTest) {
+    auto alpha = 2.0;
+    auto beta = 3.0;
+
+    /*
+    1.0, 2.0, 0.0,
+    0.0, 0.0, 3.0, 
+    4.0, 1.0, 2.0
+    */
+    auto m = lalib::SpMat<double>(
+        {1.0, 2.0, 3.0, 4.0, 1.0, 2.0},
+        {0, 2, 3, 6},
+        {0, 1, 2, 0, 1, 2}
+    );
+    auto v = lalib::DynVec<double>({2.0, 3.0, 4.0});
+
+    auto vr = lalib::DynVec<double>::filled(3, 1.0);
+    lalib::mul(alpha, m, v, beta, vr);
+
+    EXPECT_DOUBLE_EQ(alpha * 8.0 + beta, vr[0]);
+    EXPECT_DOUBLE_EQ(alpha * 12.0 + beta, vr[1]);
+    EXPECT_DOUBLE_EQ(alpha * 19.0 + beta, vr[2]);
+}

--- a/test/solver/gmres.cc
+++ b/test/solver/gmres.cc
@@ -1,0 +1,32 @@
+#include "lalib/solver/gmres.hpp"
+#include <gtest/gtest.h>
+
+TEST(GmresTests, GmresTest) {
+    auto mat = lalib::DynMat<double>(3, 3, {
+        4.0, 2.0, 6.0,
+        2.0, 5.0, 5.0,
+        6.0, 5.0, 14.0
+    });
+    auto b = lalib::DynVec<double>({2.0, 5.0, 1.0});
+    auto gmres = lalib::solver::Gmres<double, lalib::DynMat<double>>(mat, 1e-6);
+    auto sol = gmres.solve(b);
+
+    ASSERT_NEAR(1.25, sol[0], 1e-6);
+    ASSERT_NEAR(1.5, sol[1], 1e-6);
+    ASSERT_NEAR(-1.0, sol[2], 1e-6);
+}
+
+TEST(GmresTests, SpGmresTest) {
+    auto mat = lalib::SpMat<double>(
+        {4.0, 2.0, 6.0, 2.0, 5.0, 5.0, 6.0, 5.0, 14.0}, 
+        {0, 3, 6, 9}, 
+        {0, 1, 2, 0, 1, 2, 0, 1, 2}
+    );
+    auto b = lalib::DynVec<double>({2.0, 5.0, 1.0});
+    auto gmres = lalib::solver::Gmres(mat, 1e-6);
+    auto sol = gmres.solve(b);
+
+    ASSERT_NEAR(1.25, sol[0], 1e-6);
+    ASSERT_NEAR(1.5, sol[1], 1e-6);
+    ASSERT_NEAR(-1.0, sol[2], 1e-6);
+}


### PR DESCRIPTION
This pull request introduces several significant changes to the `lalib` project, including the addition of new matrix types, updates to existing matrix operations, and the inclusion of sparse matrix operations. The most important changes are summarized below:

### New Matrix Types

* Added a new `HessenbergMat` class for representing Hessenberg matrices with various methods for matrix operations.
* Introduced `DynUpperTriMat` class for dynamic upper triangular matrices with methods for matrix operations and backward substitution.
* Added `SpCooMat` and `SpMat` classes for sparse matrices in coordinate and compressed sparse row formats, respectively.

### Updates to Existing Matrix Operations

* Modified the `scale` function to return a reference to the matrix instead of a new matrix for `SizedMat`, `DynMat`, and `SpMat` types.
* Added new overloads for the `operator*` and `operator-` functions to support sparse matrices (`SpMat`). [[1]](diffhunk://#diff-bed6692c498c011648af30dad3ced8a77771256200ccd97c55bc4b4c50e2cbc2R52-R63) [[2]](diffhunk://#diff-bed6692c498c011648af30dad3ced8a77771256200ccd97c55bc4b4c50e2cbc2R80-R87)

### Inclusion of Sparse Matrix Operations

* Implemented the `mul` function for matrix-vector multiplication involving sparse matrices (`SpMat`).

### General Updates

* Updated `CMakeLists.txt` to reflect the new version of the project (0.7.0).
* Included necessary headers (`<ranges>` and `<span>`) in `dyn_mat.hpp` to support the new matrix types.

These changes enhance the functionality of the library by adding support for new matrix types and improving the efficiency of matrix operations.