### PR TITLE
Sparse Matrix Update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(lalib VERSION 0.7.0 LANGUAGES C CXX)
+project(lalib VERSION 0.7.1 LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED True)

--- a/include/lalib/ops/mat_ops.hpp
+++ b/include/lalib/ops/mat_ops.hpp
@@ -29,6 +29,12 @@ inline auto scale(const T& alpha, DynMat<T>& mat) noexcept -> DynMat<T>& {
 }
 
 template<typename T>
+inline auto scale(const T& alpha, SpCooMat<T>& mat) noexcept -> SpCooMat<T>& {
+    scal_core(alpha, mat.data(), mat.nnz());
+    return mat;
+}
+
+template<typename T>
 inline auto scale(const T& alpha, SpMat<T>& mat) noexcept -> SpMat<T>& {
     scal_core<T>(alpha, mat.data(), mat.nnz());
     return mat;
@@ -44,6 +50,13 @@ inline auto operator*(const T& alpha, const SizedMat<T, N, M>& mat) noexcept -> 
 
 template<typename T>
 inline auto operator*(const T& alpha, const DynMat<T>& mat) noexcept -> DynMat<T> {
+    auto rmat = mat;
+    scale(alpha, rmat);
+    return rmat;
+}
+
+template<typename T>
+inline auto operator*(const T& alpha, const SpCooMat<T>& mat) noexcept -> SpCooMat<T> {
     auto rmat = mat;
     scale(alpha, rmat);
     return rmat;
@@ -72,6 +85,14 @@ inline auto operator-(const SizedMat<T, N, M>& mat) noexcept -> SizedMat<T, N, M
 template<typename T>
 requires std::is_integral_v<T> || std::is_floating_point_v<T>
 inline auto operator-(const DynMat<T>& mat) noexcept -> DynMat<T> {
+    auto rmat = mat;
+    scale(-1.0, rmat);
+    return rmat;
+}
+
+template<typename T>
+requires std::is_integral_v<T> || std::is_floating_point_v<T>
+inline auto operator-(const SpCooMat<T>& mat) noexcept -> SpCooMat<T> {
     auto rmat = mat;
     scale(-1.0, rmat);
     return rmat;

--- a/test/mat/sp_mat.cc
+++ b/test/mat/sp_mat.cc
@@ -223,3 +223,79 @@ TEST(SpMatTests, CooCrsConversionTest) {
     ASSERT_EQ(crs_mat_moved(2, 1), 4.0);
     ASSERT_EQ(crs_mat_moved(2, 2), 5.0);
 }
+
+TEST(SpMatTests, CooUnitMatrixTest) {
+    auto unit_mat = lalib::SpMat<double>::unit(3);
+
+    ASSERT_EQ(unit_mat(0, 0), 1.0);
+    ASSERT_EQ(unit_mat(0, 1), 0.0);
+    ASSERT_EQ(unit_mat(0, 2), 0.0);
+    ASSERT_EQ(unit_mat(1, 0), 0.0);
+    ASSERT_EQ(unit_mat(1, 1), 1.0);
+    ASSERT_EQ(unit_mat(1, 2), 0.0);
+    ASSERT_EQ(unit_mat(2, 0), 0.0);
+    ASSERT_EQ(unit_mat(2, 1), 0.0);
+    ASSERT_EQ(unit_mat(2, 2), 1.0);
+}
+
+TEST(SpMatTests, CrsUnitMatrixTest) {
+    auto unit_mat = lalib::SpMat<double>::unit(3);
+
+    ASSERT_EQ(unit_mat(0, 0), 1.0);
+    ASSERT_EQ(unit_mat(0, 1), 0.0);
+    ASSERT_EQ(unit_mat(0, 2), 0.0);
+    ASSERT_EQ(unit_mat(1, 0), 0.0);
+    ASSERT_EQ(unit_mat(1, 1), 1.0);
+    ASSERT_EQ(unit_mat(1, 2), 0.0);
+    ASSERT_EQ(unit_mat(2, 0), 0.0);
+    ASSERT_EQ(unit_mat(2, 1), 0.0);
+    ASSERT_EQ(unit_mat(2, 2), 1.0);
+}
+
+TEST(SpMatTests, CooMatrixAddAssignTest) {
+    auto mat1 = lalib::SpCooMat<double>::unit(2);
+    auto mat2 = lalib::SpCooMat<double> {
+        { 1.0, 2.0, 3.0, 4.0 },
+        { 0, 0, 1, 1 },
+        { 0, 1, 0, 1 }
+    };
+
+    mat1 += mat2;
+
+    ASSERT_EQ(mat1(0, 0), 2.0);
+    ASSERT_EQ(mat1(0, 1), 2.0);
+    ASSERT_EQ(mat1(1, 0), 3.0);
+    ASSERT_EQ(mat1(1, 1), 5.0);
+
+
+    auto mat3 = lalib::SpCooMat<double>::unit(4);
+    // mat4 = 
+    //  1.0, 2.0, 0.0, 0.0
+    //  3.0, 0.0, 0.0, 0.0
+    //  0.0, 4.0, 0.0, 0.0
+    //  0.0, 0.0, 0.0, 5.0
+    auto mat4 = lalib::SpCooMat<double> {
+        { 1.0, 2.0, 3.0, 4.0, 5.0 },
+        { 0, 0, 1, 2, 3 },
+        { 0, 1, 0 , 1, 3 }
+    };
+
+    mat3 += mat4;
+
+    ASSERT_EQ(mat3(0, 0), 2.0);
+    ASSERT_EQ(mat3(0, 1), 2.0);
+    ASSERT_EQ(mat3(0, 2), 0.0);
+    ASSERT_EQ(mat3(0, 3), 0.0);
+    ASSERT_EQ(mat3(1, 0), 3.0);
+    ASSERT_EQ(mat3(1, 1), 1.0);
+    ASSERT_EQ(mat3(1, 2), 0.0);
+    ASSERT_EQ(mat3(1, 3), 0.0);
+    ASSERT_EQ(mat3(2, 0), 0.0);
+    ASSERT_EQ(mat3(2, 1), 4.0);
+    ASSERT_EQ(mat3(2, 2), 1.0);
+    ASSERT_EQ(mat3(2, 3), 0.0);
+    ASSERT_EQ(mat3(3, 0), 0.0);
+    ASSERT_EQ(mat3(3, 1), 0.0);
+    ASSERT_EQ(mat3(3, 2), 0.0);
+    ASSERT_EQ(mat3(3, 3), 6.0);
+}

--- a/test/ops/mat_ops.cc
+++ b/test/ops/mat_ops.cc
@@ -23,6 +23,32 @@ TEST(MatOpsTest, ScaleTest) {
     EXPECT_DOUBLE_EQ(12.0, rmat(1, 2));
 }
 
+TEST(MatOpsTests, SpCooScaleTest) {
+    auto mat = lalib::SpCooMat<double>(
+        { 1.0, 2.0, 3.0, 4.0 },
+        { 0, 0, 1, 1 },
+        { 0, 1, 0, 1 }
+    );
+    scale(2.0, mat);
+
+    EXPECT_DOUBLE_EQ(2.0, mat(0, 0));
+    EXPECT_DOUBLE_EQ(4.0, mat(0, 1));
+    EXPECT_DOUBLE_EQ(6.0, mat(1, 0));
+    EXPECT_DOUBLE_EQ(8.0, mat(1, 1));
+
+    auto mat2 = lalib::SpCooMat<double>(
+        { 1.0, 2.0, 3.0, 4.0 },
+        { 0, 0, 1, 1 },
+        { 0, 1, 0, 1 }
+    );
+    auto rmat = 2.0 * mat2;
+
+    EXPECT_DOUBLE_EQ(2.0, rmat(0, 0));
+    EXPECT_DOUBLE_EQ(4.0, rmat(0, 1));
+    EXPECT_DOUBLE_EQ(6.0, rmat(1, 0));
+    EXPECT_DOUBLE_EQ(8.0, rmat(1, 1));
+}
+
 TEST(MatOpsTests, SpScaleTest) {
     auto mat = lalib::SpMat<double>(
         { 1.0, 2.0, 3.0, 4.0 },


### PR DESCRIPTION
This pull request includes several enhancements and new features for the `lalib` project, primarily focusing on the sparse matrix (`SpCooMat` and `SpMat`) functionalities. The most significant changes include the addition of unit matrix creation, arithmetic assignment operators, and new test cases to ensure the correctness of these features.

### Enhancements to Sparse Matrices:

* Added a `unit` method to create unit matrices for both `SpCooMat` and `SpMat` structs. [[1]](diffhunk://#diff-8e76ccfc41cca15bdcd7e1d1f88421fb0f48385b26f8ab571ea2cb571714d527R38-R43) [[2]](diffhunk://#diff-8e76ccfc41cca15bdcd7e1d1f88421fb0f48385b26f8ab571ea2cb571714d527R154-R158) [[3]](diffhunk://#diff-8e76ccfc41cca15bdcd7e1d1f88421fb0f48385b26f8ab571ea2cb571714d527R264-R278) [[4]](diffhunk://#diff-8e76ccfc41cca15bdcd7e1d1f88421fb0f48385b26f8ab571ea2cb571714d527R467-R480)
* Introduced arithmetic assignment operators (`operator+=`) for `SpCooMat` and `SpMat` to support matrix addition. [[1]](diffhunk://#diff-8e76ccfc41cca15bdcd7e1d1f88421fb0f48385b26f8ab571ea2cb571714d527R108-R122) [[2]](diffhunk://#diff-8e76ccfc41cca15bdcd7e1d1f88421fb0f48385b26f8ab571ea2cb571714d527R225-R240) [[3]](diffhunk://#diff-8e76ccfc41cca15bdcd7e1d1f88421fb0f48385b26f8ab571ea2cb571714d527R323-R413)

### Codebase Improvements:

* Implemented a private `_sort` method in `SpCooMat` to ensure the internal data is sorted correctly. [[1]](diffhunk://#diff-8e76ccfc41cca15bdcd7e1d1f88421fb0f48385b26f8ab571ea2cb571714d527R108-R122) [[2]](diffhunk://#diff-8e76ccfc41cca15bdcd7e1d1f88421fb0f48385b26f8ab571ea2cb571714d527R323-R413)
* Included additional headers in `include/lalib/mat/sp_mat.hpp` to support new functionalities.

### New Test Cases:

* Added unit tests for the new `unit` method and arithmetic assignment operators to verify their correctness. [[1]](diffhunk://#diff-af1dea3d6fc0f7d18c8c76ff796748a09a17c951ba96590b1a810183f3eb6d74R226-R301) [[2]](diffhunk://#diff-72eecc9e190ca32b60dc22e836859d1525a594e815ae44d7024cf298f0a00ae2R26-R51)
* Extended tests in `test/ops/mat_ops.cc` to cover scaling operations for `SpCooMat`.

### Miscellaneous:

* Updated the project version in `CMakeLists.txt` from 0.7.0 to 0.7.1.