### PR TITLE
[FIX] remove shape check from SpCooMat addition operator

### DIFF
--- a/include/lalib/mat/sp_mat.hpp
+++ b/include/lalib/mat/sp_mat.hpp
@@ -322,10 +322,6 @@ constexpr auto SpCooMat<T>::operator=(SpCooMat<T>&& mat) noexcept -> SpCooMat<T>
 
 template<typename T>
 auto SpCooMat<T>::operator+=(const SpCooMat<T>& mat) -> SpCooMat<T>& {
-    if (this->shape() != mat.shape()) {
-        throw std::runtime_error("The shape of the matrices must be the same.");
-    }
-
     this->_val.reserve(this->_val.size() + mat.nnz());
     this->_row_ids.reserve(this->_row_ids.size() + mat.nnz());
     this->_col_ids.reserve(this->_col_ids.size() + mat.nnz());


### PR DESCRIPTION
This pull request includes changes to the `SpCooMat` class in the `include/lalib/mat/sp_mat.hpp` file. The most significant change is the removal of the shape check in the `operator+=` method.

Codebase simplification:

* [`include/lalib/mat/sp_mat.hpp`](diffhunk://#diff-8e76ccfc41cca15bdcd7e1d1f88421fb0f48385b26f8ab571ea2cb571714d527L325-L328): Removed the shape check in the `operator+=` method to streamline the addition operation because the method `shape` did not reflect actual size of the sparse matrix.