### PR TITLE
[MOD] fix infinite loop in SpCooMat addition operator

### DIFF
--- a/include/lalib/mat/sp_mat.hpp
+++ b/include/lalib/mat/sp_mat.hpp
@@ -381,7 +381,7 @@ auto SpCooMat<T>::operator+=(const SpCooMat<T>& mat) -> SpCooMat<T>& {
         auto cursor_end = std::distance(this->_row_ids.begin(), row_iter_end) - 1;
         auto rcursor_end = std::distance(mat._row_ids.begin(), rrow_iter_end) - 1;
 
-        while (true) {
+        while (rcursor <= rcursor_end) {
             if (this->_col_ids[cursor] == mat._col_ids[rcursor]) {
                 this->_val[cursor] += mat._val[rcursor];
 


### PR DESCRIPTION
This pull request includes a change to the `operator+=` method in the `SpCooMat` class to fix a potential infinite loop issue by modifying the loop condition.

* [`include/lalib/mat/sp_mat.hpp`](diffhunk://#diff-8e76ccfc41cca15bdcd7e1d1f88421fb0f48385b26f8ab571ea2cb571714d527L384-R384): Changed the loop condition in `auto SpCooMat<T>::operator+=(const SpCooMat<T>& mat) -> SpCooMat<T>&` to ensure the loop terminates correctly.